### PR TITLE
Error back

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
 
@@ -22,7 +22,7 @@ configure(allprojects) {
         androidMinSdkVersion 		        = 14
         androidTargetSdkVersion             = 24
         androidCompileSdkVersion            = 24
-        androidBuildToolsVersion            = "25.0.0"
+        androidBuildToolsVersion            = "25.0.2"
         androidSupportLibraryVersion        = "25.0.0"
 
         /* Sample only */

--- a/material-stepper/src/main/java/com/stepstone/stepper/StepperLayout.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/StepperLayout.java
@@ -40,7 +40,7 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.LinearLayout;
 
-import com.stepstone.stepper.adapter.AbstractStepAdapter;
+import com.stepstone.stepper.adapter.StepAdapter;
 import com.stepstone.stepper.internal.ColorableProgressBar;
 import com.stepstone.stepper.internal.DottedProgressBar;
 import com.stepstone.stepper.internal.RightNavigationButton;
@@ -198,7 +198,7 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
 
     private int mTypeIdentifier = AbstractStepperType.PROGRESS_BAR;
 
-    private AbstractStepAdapter mStepAdapter;
+    private StepAdapter mStepAdapter;
 
     private AbstractStepperType mStepperType;
 
@@ -250,9 +250,9 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
      *
      * @param stepAdapter step adapter
      */
-    public void setAdapter(@NonNull AbstractStepAdapter stepAdapter) {
+    public void setAdapter(@NonNull StepAdapter stepAdapter) {
         this.mStepAdapter = stepAdapter;
-        mPager.setAdapter(stepAdapter);
+        mPager.setAdapter(stepAdapter.getPagerAdapter());
 
         mStepperType.onNewAdapter(stepAdapter);
 
@@ -272,7 +272,7 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
      * @param stepAdapter         step adapter
      * @param currentStepPosition the initial step position, must be in the range of the adapter item count
      */
-    public void setAdapter(@NonNull AbstractStepAdapter stepAdapter, @IntRange(from = 0) int currentStepPosition) {
+    public void setAdapter(@NonNull StepAdapter stepAdapter, @IntRange(from = 0) int currentStepPosition) {
         this.mCurrentStepPosition = currentStepPosition;
         setAdapter(stepAdapter);
     }
@@ -539,7 +539,7 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
 
         if (!isLast) {
             int nextButtonTextForStep = mStepAdapter.getNextButtonText(newStepPosition);
-            if (nextButtonTextForStep == AbstractStepAdapter.DEFAULT_NEXT_BUTTON_TEXT) {
+            if (nextButtonTextForStep == StepAdapter.DEFAULT_NEXT_BUTTON_TEXT) {
                 mNextNavigationButton.setText(mNextButtonText);
             } else {
                 mNextNavigationButton.setText(nextButtonTextForStep);

--- a/material-stepper/src/main/java/com/stepstone/stepper/StepperLayout.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/StepperLayout.java
@@ -47,6 +47,7 @@ import com.stepstone.stepper.internal.RightNavigationButton;
 import com.stepstone.stepper.internal.TabsContainer;
 import com.stepstone.stepper.type.AbstractStepperType;
 import com.stepstone.stepper.type.StepperTypeFactory;
+import com.stepstone.stepper.type.TabsStepperType;
 import com.stepstone.stepper.util.AnimationUtil;
 import com.stepstone.stepper.util.TintUtil;
 
@@ -204,6 +205,8 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
 
     private int mCurrentStepPosition;
 
+    private boolean mShowErrorStateOnBack;
+
     @NonNull
     private StepperListener mListener = StepperListener.NULL;
 
@@ -323,6 +326,14 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
 
     public void setCompleteButtonVerificationFailed(boolean verificationFailed) {
         mCompleteNavigationButton.setVerificationFailed(verificationFailed);
+    }
+
+    /**
+     * Set whether when going backwards should clear the error state from the Tab. Default is false
+     * @param mShowErrorStateOnBack
+     */
+    public void setShowErrorStateOnBack(boolean mShowErrorStateOnBack) {
+        this.mShowErrorStateOnBack = mShowErrorStateOnBack;
     }
 
     private void init(AttributeSet attrs, @AttrRes int defStyleAttr) {
@@ -455,6 +466,8 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
                 mTypeIdentifier = a.getInt(R.styleable.StepperLayout_ms_stepperType, DEFAULT_TAB_DIVIDER_WIDTH);
             }
 
+            mShowErrorStateOnBack = a.getBoolean(R.styleable.StepperLayout_ms_showErrorStateOnBack, false);
+
             a.recycle();
         }
     }
@@ -496,6 +509,11 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
         if (verifyCurrentStep(step)) {
             return;
         }
+
+        //if moving forward and got no errors, set hasError to false, so we can have the tab with the check mark.
+        if(mStepperType instanceof TabsStepperType)
+            mTabsContainer.setErrorStep(mCurrentStepPosition, false);
+
         OnNextClickedCallback onNextClickedCallback = new OnNextClickedCallback();
         if (step instanceof BlockingStep) {
             ((BlockingStep) step).onNextClicked(onNextClickedCallback);
@@ -517,6 +535,11 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
         Step step = findCurrentStep();
         if (step != null) {
             step.onError(verificationError);
+
+            //if moving forward and got errors, set hasError to true, showing the error drawable.
+            if(mStepperType instanceof TabsStepperType)
+                mTabsContainer.setErrorStep(mCurrentStepPosition, true);
+
         }
         mListener.onError(verificationError);
     }
@@ -544,6 +567,11 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
             } else {
                 mNextNavigationButton.setText(nextButtonTextForStep);
             }
+        }
+
+        //needs to be here in case user for any reason decide to change whether or not to show errors when going back.
+        if(mStepperType instanceof TabsStepperType) {
+            mTabsContainer.setShowErrorStateOnBack(mShowErrorStateOnBack);
         }
 
         mStepperType.onStepSelected(newStepPosition);

--- a/material-stepper/src/main/java/com/stepstone/stepper/adapter/AbstractFragmentStepAdapter.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/adapter/AbstractFragmentStepAdapter.java
@@ -1,0 +1,65 @@
+/*
+Copyright 2016 StepStone Services
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.stepstone.stepper.adapter;
+
+import android.support.annotation.StringRes;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentPagerAdapter;
+import android.support.v4.view.PagerAdapter;
+import android.support.v4.view.ViewPager;
+
+import com.stepstone.stepper.Step;
+
+/**
+ * A base adapter class which returns step fragments to use inside of the {@link com.stepstone.stepper.StepperLayout}.
+ */
+public abstract class AbstractFragmentStepAdapter
+        extends FragmentPagerAdapter
+        implements StepAdapter {
+
+    private final FragmentManager mFragmentManager;
+
+    public AbstractFragmentStepAdapter(FragmentManager fm) {
+        super(fm);
+        mFragmentManager = fm;
+    }
+
+    @Override
+    public final Fragment getItem(int position) {
+        return (Fragment) createStep(position);
+    }
+
+    /** {@inheritDoc} */
+    @SuppressWarnings("unchecked")
+    public Step findStep(ViewPager viewPager, int position) {
+        String fragmentTag =  "android:switcher:" + viewPager.getId() + ":" + this.getItemId(position);
+        return (Step) mFragmentManager.findFragmentByTag(fragmentTag);
+    }
+
+    /** {@inheritDoc} */
+    @StringRes
+    public int getNextButtonText(int position) {
+        return DEFAULT_NEXT_BUTTON_TEXT;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public final PagerAdapter getPagerAdapter() {
+        return this;
+    }
+}

--- a/material-stepper/src/main/java/com/stepstone/stepper/adapter/AbstractStepAdapter.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/adapter/AbstractStepAdapter.java
@@ -1,75 +1,23 @@
-/*
-Copyright 2016 StepStone Services
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
-
 package com.stepstone.stepper.adapter;
 
-import android.support.annotation.StringRes;
-import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentManager;
-import android.support.v4.app.FragmentPagerAdapter;
-import android.support.v4.view.ViewPager;
-
-import com.stepstone.stepper.Step;
+import android.support.v4.view.PagerAdapter;
 
 /**
- * A base adapter class which returns step fragments to use inside of the {@link com.stepstone.stepper.StepperLayout}.
+ * A base adapter class which returns step to use inside of the {@link com.stepstone.stepper.StepperLayout}.
+ * This class is intended to be inherited if you need to use {@link com.stepstone.stepper.StepperLayout} without fragments.
+ * Otherwise, you should use {@link AbstractFragmentStepAdapter}
  */
-public abstract class AbstractStepAdapter<T extends Fragment & Step> extends FragmentPagerAdapter {
+public abstract class AbstractStepAdapter extends PagerAdapter implements StepAdapter {
 
-    public static final int DEFAULT_NEXT_BUTTON_TEXT = -1;
-
-    private final FragmentManager mFragmentManager;
-
-    public AbstractStepAdapter(FragmentManager fm) {
-        super(fm);
-        mFragmentManager = fm;
-    }
-
+    /** {@inheritDoc} */
     @Override
-    public final T getItem(int position) {
-        return createStep(position);
-    }
-
-    protected abstract T createStep(int position);
-
-    /**
-     * Finds the given step without creating it.
-     * @see FragmentPagerAdapter#makeFragmentName(int, long)
-     * @param viewPager view pager to use for displaying step fragments
-     * @param position step position
-     * @return step fragment
-     */
-    public Step findStep(ViewPager viewPager, int position) {
-        String fragmentTag =  "android:switcher:" + viewPager.getId() + ":" + this.getItemId(position);
-        return (Step) mFragmentManager.findFragmentByTag(fragmentTag);
-    }
-
-    /**
-     * Allows to override the text on the Next button per step.
-     * For a given step position you need to return a String resource ID for the label to be used.
-     * If you wish to change the text for selected steps only (and leave the default for the rest)
-     * then return {@link #DEFAULT_NEXT_BUTTON_TEXT} for the default ones.
-     * By default this method returns {@link #DEFAULT_NEXT_BUTTON_TEXT} for all steps.
-     * This method is not invoked for the last step.
-     * @param position step position
-     * @return a String resource ID to override the default button text or {@link #DEFAULT_NEXT_BUTTON_TEXT} if the default text should be kept
-     */
-    @StringRes
     public int getNextButtonText(int position) {
         return DEFAULT_NEXT_BUTTON_TEXT;
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public final PagerAdapter getPagerAdapter() {
+        return this;
+    }
 }

--- a/material-stepper/src/main/java/com/stepstone/stepper/adapter/StepAdapter.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/adapter/StepAdapter.java
@@ -1,0 +1,56 @@
+package com.stepstone.stepper.adapter;
+
+import android.support.annotation.StringRes;
+import android.support.v4.app.FragmentPagerAdapter;
+import android.support.v4.view.PagerAdapter;
+import android.support.v4.view.ViewPager;
+
+import com.stepstone.stepper.Step;
+
+/**
+ * Interface to be used as model to {@link com.stepstone.stepper.StepperLayout}.
+ */
+public interface StepAdapter {
+
+    int DEFAULT_NEXT_BUTTON_TEXT = -1;
+
+    /**
+     * Create each step of the {@link com.stepstone.stepper.StepperLayout}.
+     * @param position The position of the {@link PagerAdapter} to be used inside the {@link ViewPager}.
+     * @return the step to be used inside the {@link com.stepstone.stepper.StepperLayout}.
+     */
+    Step createStep(int position);
+
+    /**
+     * Finds the given step without creating it.
+     * @see FragmentPagerAdapter#makeFragmentName(int, long)
+     * @param viewPager view pager to use for displaying step fragments
+     * @param position step position
+     * @return step fragment
+     */
+    Step findStep(ViewPager viewPager, int position);
+
+    /**
+     * Allows to override the text on the Next button per step.
+     * For a given step position you need to return a String resource ID for the label to be used.
+     * If you wish to change the text for selected steps only (and leave the default for the rest)
+     * then return {@link #DEFAULT_NEXT_BUTTON_TEXT} for the default ones.
+     * By default this method returns {@link #DEFAULT_NEXT_BUTTON_TEXT} for all steps.
+     * This method is not invoked for the last step.
+     * @param position step position
+     * @return a String resource ID to override the default button text or {@link #DEFAULT_NEXT_BUTTON_TEXT} if the default text should be kept
+     */
+    @StringRes int getNextButtonText(int position);
+
+    /**
+     * Get the step count.
+     * @return the quantity of steps
+     */
+    int getCount();
+
+    /**
+     * Method for internal purpose. Should not be inherited.
+     * @return the adapter to be used in the {@link ViewPager}.
+     */
+    PagerAdapter getPagerAdapter();
+}

--- a/material-stepper/src/main/java/com/stepstone/stepper/internal/StepTab.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/internal/StepTab.java
@@ -56,7 +56,11 @@ public class StepTab extends RelativeLayout {
 
     private final ImageView mStepDoneIndicator;
 
+    private final ImageView mStepErrorIndicator;
+
     private int mDividerWidth = StepperLayout.DEFAULT_TAB_DIVIDER_WIDTH;
+
+    private boolean hasError;
 
     public StepTab(Context context) {
         this(context, null);
@@ -75,6 +79,7 @@ public class StepTab extends RelativeLayout {
 
         mStepNumber = (TextView) findViewById(R.id.ms_stepNumber);
         mStepDoneIndicator = (ImageView) findViewById(R.id.ms_stepDoneIndicator);
+        mStepErrorIndicator = (ImageView) findViewById(R.id.ms_stepErrorIndicator);
         mStepDivider = findViewById(R.id.ms_stepDivider);
         mStepTitle = ((TextView) findViewById(R.id.ms_stepTitle));
     }
@@ -92,13 +97,34 @@ public class StepTab extends RelativeLayout {
      * @param done true if the step is done and the step's number should be replaced with a <i>done</i> icon, false otherwise
      * @param current true if the step is the current step, false otherwise
      */
-    public void updateState(final boolean done, final boolean current) {
+    public void updateState(final boolean done, final boolean showErrorOnBack, final boolean current) {
+        //if this tab has errors and the user decide not to clear when going backwards, simply ignore the update
+        if(this.hasError && showErrorOnBack)
+            return;
+
         mStepDoneIndicator.setVisibility(done ? View.VISIBLE : View.GONE);
         mStepNumber.setVisibility(!done ? View.VISIBLE : View.GONE);
+        mStepErrorIndicator.setVisibility(GONE);
         colorViewBackground(done ? mStepDoneIndicator : mStepNumber, done || current);
+
+        this.hasError = false;
 
         mStepTitle.setTypeface(current ? Typeface.DEFAULT_BOLD : Typeface.DEFAULT);
         mStepTitle.setAlpha(done || current ? OPAQUE_ALPHA : INACTIVE_STEP_TITLE_ALPHA);
+    }
+
+    /**
+     * Update the error state of this tab. If it has error, show the error drawable.
+     * @param hasError whether the tab has errors or not.
+     */
+    public void updateErrorState(boolean hasError) {
+        if(hasError) {
+            mStepDoneIndicator.setVisibility(View.GONE);
+            mStepNumber.setVisibility(View.GONE);
+            mStepErrorIndicator.setVisibility(VISIBLE);
+        }
+
+        this.hasError = hasError;
     }
 
     /**

--- a/material-stepper/src/main/java/com/stepstone/stepper/internal/TabsContainer.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/internal/TabsContainer.java
@@ -79,6 +79,8 @@ public class TabsContainer extends FrameLayout {
 
     private List<Integer> mStepTitles;
 
+    private boolean mShowErrorStateOnBack;
+
     public TabsContainer(Context context) {
         this(context, null);
     }
@@ -152,11 +154,27 @@ public class TabsContainer extends FrameLayout {
             StepTab childTab = (StepTab) mTabsInnerContainer.getChildAt(i);
             boolean done = i < newStepPosition;
             final boolean current = i == newStepPosition;
-            childTab.updateState(done, current);
+            childTab.updateState(done, mShowErrorStateOnBack, current);
             if (current) {
                 mTabsScrollView.smoothScrollTo(childTab.getLeft() - mContainerLateralPadding, 0);
             }
         }
+    }
+
+    /**
+     * Set whether when going backwards should clear the error state from the Tab. Default is false
+     * @param mShowErrorStateOnBack
+     */
+    public void setShowErrorStateOnBack(boolean mShowErrorStateOnBack) {
+        this.mShowErrorStateOnBack = mShowErrorStateOnBack;
+    }
+
+    public void setErrorStep(int stepPosition, boolean hasError){
+        if(mStepTitles.size() < stepPosition)
+            return;
+
+        StepTab childTab = (StepTab) mTabsInnerContainer.getChildAt(stepPosition);
+        childTab.updateErrorState(hasError);
     }
 
     private View createStepTab(final int position, @StringRes int title) {

--- a/material-stepper/src/main/java/com/stepstone/stepper/type/AbstractStepperType.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/type/AbstractStepperType.java
@@ -20,7 +20,7 @@ import android.support.annotation.ColorInt;
 import android.support.annotation.NonNull;
 
 import com.stepstone.stepper.StepperLayout;
-import com.stepstone.stepper.adapter.AbstractStepAdapter;
+import com.stepstone.stepper.adapter.StepAdapter;
 
 /**
  * A base stepper type all stepper types must extend.
@@ -58,7 +58,7 @@ public abstract class AbstractStepperType {
      * Called when {@link StepperLayout}'s adapter gets changed
      * @param stepAdapter new stepper adapter
      */
-    public abstract void onNewAdapter(@NonNull AbstractStepAdapter<?> stepAdapter);
+    public abstract void onNewAdapter(@NonNull StepAdapter stepAdapter);
 
     @ColorInt
     protected int getSelectedColor() {

--- a/material-stepper/src/main/java/com/stepstone/stepper/type/DotsStepperType.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/type/DotsStepperType.java
@@ -21,7 +21,7 @@ import android.view.View;
 
 import com.stepstone.stepper.R;
 import com.stepstone.stepper.StepperLayout;
-import com.stepstone.stepper.adapter.AbstractStepAdapter;
+import com.stepstone.stepper.adapter.StepAdapter;
 import com.stepstone.stepper.internal.DottedProgressBar;
 
 /**
@@ -51,7 +51,7 @@ public class DotsStepperType extends AbstractStepperType {
      * {@inheritDoc}
      */
     @Override
-    public void onNewAdapter(@NonNull AbstractStepAdapter stepAdapter) {
+    public void onNewAdapter(@NonNull StepAdapter stepAdapter) {
         final int stepCount = stepAdapter.getCount();
         mDottedProgressBar.setDotCount(stepCount);
         mDottedProgressBar.setVisibility(stepCount > 1 ? View.VISIBLE : View.GONE);

--- a/material-stepper/src/main/java/com/stepstone/stepper/type/ProgressBarStepperType.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/type/ProgressBarStepperType.java
@@ -21,7 +21,7 @@ import android.view.View;
 
 import com.stepstone.stepper.R;
 import com.stepstone.stepper.StepperLayout;
-import com.stepstone.stepper.adapter.AbstractStepAdapter;
+import com.stepstone.stepper.adapter.StepAdapter;
 import com.stepstone.stepper.internal.ColorableProgressBar;
 
 /**
@@ -51,7 +51,7 @@ public class ProgressBarStepperType extends AbstractStepperType {
      * {@inheritDoc}
      */
     @Override
-    public void onNewAdapter(@NonNull AbstractStepAdapter stepAdapter) {
+    public void onNewAdapter(@NonNull StepAdapter stepAdapter) {
         final int stepCount = stepAdapter.getCount();
         mProgressBar.setMax(stepAdapter.getCount());
         mProgressBar.setVisibility(stepCount > 1 ? View.VISIBLE : View.GONE);

--- a/material-stepper/src/main/java/com/stepstone/stepper/type/TabsStepperType.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/type/TabsStepperType.java
@@ -22,7 +22,7 @@ import android.view.View;
 import com.stepstone.stepper.R;
 import com.stepstone.stepper.Step;
 import com.stepstone.stepper.StepperLayout;
-import com.stepstone.stepper.adapter.AbstractStepAdapter;
+import com.stepstone.stepper.adapter.StepAdapter;
 import com.stepstone.stepper.internal.TabsContainer;
 
 import java.util.ArrayList;
@@ -57,11 +57,11 @@ public class TabsStepperType extends AbstractStepperType {
      * {@inheritDoc}
      */
     @Override
-    public void onNewAdapter(@NonNull AbstractStepAdapter<?> stepAdapter) {
+    public void onNewAdapter(@NonNull StepAdapter stepAdapter) {
         List<Integer> titles = new ArrayList<>();
         final int stepCount = stepAdapter.getCount();
         for (int i = 0; i < stepCount; i++) {
-            final Step step = stepAdapter.getItem(i);
+            final Step step = (Step) stepAdapter.createStep(i);
             titles.add(step.getName());
         }
         mTabsContainer.setSteps(titles);

--- a/material-stepper/src/main/res/drawable/ic_warning.xml
+++ b/material-stepper/src/main/res/drawable/ic_warning.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M1,21h22L12,2 1,21zM13,18h-2v-2h2v2zM13,14h-2v-4h2v4z"/>
+</vector>

--- a/material-stepper/src/main/res/layout/ms_step_tab.xml
+++ b/material-stepper/src/main/res/layout/ms_step_tab.xml
@@ -27,6 +27,15 @@
             app:srcCompat="@drawable/ic_check"
             android:visibility="gone" />
 
+        <android.support.v7.widget.AppCompatImageView
+            android:id="@+id/ms_stepErrorIndicator"
+            android:layout_width="@dimen/ms_step_tab_counter_size"
+            android:layout_height="@dimen/ms_step_tab_counter_size"
+            android:scaleType="centerInside"
+            app:srcCompat="@drawable/ic_warning"
+            android:tint="@color/ms_errorColor"
+            android:visibility="gone" />
+
     </FrameLayout>
 
     <TextView

--- a/material-stepper/src/main/res/values/attrs.xml
+++ b/material-stepper/src/main/res/values/attrs.xml
@@ -49,6 +49,9 @@ limitations under the License.
 
         <!-- Flag indicating if the Back (Previous step) button should be shown on the first step. False by default. -->
         <attr name="ms_showBackButtonOnFirstStep" format="boolean" />
+
+        <!-- Flag indicating wheter to keep showing the error state when user moves back. Only available with 'tabs' type. False by default. -->
+        <attr name="ms_showErrorStateOnBack" format="boolean" />
         
         <!-- REQUIRED: Type of the stepper-->
         <attr name="ms_stepperType">

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -8,7 +8,6 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-
         <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -16,27 +15,21 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-
         <activity android:name=".DefaultDotsActivity" />
         <activity android:name=".StyledDotsActivity" />
-        <activity android:name=".ThemedDotsActivity" android:theme="@style/AppTheme.DotStepper" />
-
+        <activity
+            android:name=".ThemedDotsActivity"
+            android:theme="@style/AppTheme.DotStepper" />
         <activity android:name=".DefaultProgressBarActivity" />
         <activity android:name=".StyledProgressBarActivity" />
-
         <activity android:name=".DefaultTabsActivity" />
         <activity android:name=".StyledTabsActivity" />
-
         <activity android:name=".CombinationActivity" />
-        
         <activity android:name=".CustomPageTransformerActivity" />
-
         <activity android:name=".DelayedTransitionStepperActivity" />
-
         <activity android:name=".DifferentNextButtonStepperActivity" />
-
         <activity android:name=".ReturnButtonActivity" />
-
+        <activity android:name=".NoFragmentsActivity"/>
     </application>
 
 </manifest>

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
         <activity android:name=".StyledProgressBarActivity" />
         <activity android:name=".DefaultTabsActivity" />
         <activity android:name=".StyledTabsActivity" />
+        <activity android:name=".ShowErrorOnBackTabActivity"/>
         <activity android:name=".CombinationActivity" />
         <activity android:name=".CustomPageTransformerActivity" />
         <activity android:name=".DelayedTransitionStepperActivity" />

--- a/sample/src/main/java/com/stepstone/stepper/sample/AbstractStepperActivity.java
+++ b/sample/src/main/java/com/stepstone/stepper/sample/AbstractStepperActivity.java
@@ -31,7 +31,7 @@ public abstract class AbstractStepperActivity extends AppCompatActivity implemen
 
     private static final String CURRENT_STEP_POSITION_KEY = "position";
 
-    StepperLayout mStepperLayout;
+    protected StepperLayout mStepperLayout;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/sample/src/main/java/com/stepstone/stepper/sample/DelayedTransitionStepperActivity.java
+++ b/sample/src/main/java/com/stepstone/stepper/sample/DelayedTransitionStepperActivity.java
@@ -17,13 +17,10 @@ limitations under the License.
 package com.stepstone.stepper.sample;
 
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentManager;
 import android.support.v7.app.AppCompatActivity;
 
 import com.stepstone.stepper.StepperLayout;
-import com.stepstone.stepper.adapter.AbstractStepAdapter;
-import com.stepstone.stepper.sample.step.DelayedTransitionStepFragmentSample;
+import com.stepstone.stepper.sample.adapter.DelayedTransitionFragmentStepAdapter;
 
 public class DelayedTransitionStepperActivity extends AppCompatActivity {
 
@@ -39,7 +36,7 @@ public class DelayedTransitionStepperActivity extends AppCompatActivity {
         setContentView(R.layout.activity_default_dots);
         mStepperLayout = (StepperLayout) findViewById(R.id.stepperLayout);
         int startingStepPosition = savedInstanceState != null ? savedInstanceState.getInt(CURRENT_STEP_POSITION_KEY) : 0;
-        mStepperLayout.setAdapter(new MyStepperAdapter(getSupportFragmentManager()), startingStepPosition);
+        mStepperLayout.setAdapter(new DelayedTransitionFragmentStepAdapter(getSupportFragmentManager()), startingStepPosition);
     }
 
     @Override
@@ -55,32 +52,6 @@ public class DelayedTransitionStepperActivity extends AppCompatActivity {
             mStepperLayout.setCurrentStepPosition(currentStepPosition - 1);
         } else {
             finish();
-        }
-    }
-
-    private static class MyStepperAdapter extends AbstractStepAdapter {
-
-        MyStepperAdapter(FragmentManager fm) {
-            super(fm);
-        }
-
-        @Override
-        public Fragment createStep(int position) {
-            switch (position) {
-                case 0:
-                    return DelayedTransitionStepFragmentSample.newInstance(R.layout.fragment_step);
-                case 1:
-                    return DelayedTransitionStepFragmentSample.newInstance(R.layout.fragment_step2);
-                case 2:
-                    return DelayedTransitionStepFragmentSample.newInstance(R.layout.fragment_step3);
-                default:
-                    throw new IllegalArgumentException("Unsupported position: " + position);
-            }
-        }
-
-        @Override
-        public int getCount() {
-            return 3;
         }
     }
 

--- a/sample/src/main/java/com/stepstone/stepper/sample/DifferentNextButtonStepperActivity.java
+++ b/sample/src/main/java/com/stepstone/stepper/sample/DifferentNextButtonStepperActivity.java
@@ -17,14 +17,10 @@ limitations under the License.
 package com.stepstone.stepper.sample;
 
 import android.os.Bundle;
-import android.support.annotation.StringRes;
-import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentManager;
 import android.support.v7.app.AppCompatActivity;
 
 import com.stepstone.stepper.StepperLayout;
-import com.stepstone.stepper.adapter.AbstractStepAdapter;
-import com.stepstone.stepper.sample.step.StepFragmentSample;
+import com.stepstone.stepper.sample.adapter.NextButtonsSampleFragmentStepAdapter;
 
 public class DifferentNextButtonStepperActivity extends AppCompatActivity {
 
@@ -40,7 +36,7 @@ public class DifferentNextButtonStepperActivity extends AppCompatActivity {
         setContentView(R.layout.activity_default_dots);
         mStepperLayout = (StepperLayout) findViewById(R.id.stepperLayout);
         int startingStepPosition = savedInstanceState != null ? savedInstanceState.getInt(CURRENT_STEP_POSITION_KEY) : 0;
-        mStepperLayout.setAdapter(new DifferentNextButtonStepperActivity.MyStepperAdapter(getSupportFragmentManager()), startingStepPosition);
+        mStepperLayout.setAdapter(new NextButtonsSampleFragmentStepAdapter(getSupportFragmentManager()), startingStepPosition);
 
     }
 
@@ -60,43 +56,4 @@ public class DifferentNextButtonStepperActivity extends AppCompatActivity {
         }
     }
 
-    private static class MyStepperAdapter extends AbstractStepAdapter {
-
-        MyStepperAdapter(FragmentManager fm) {
-            super(fm);
-        }
-
-        @Override
-        public Fragment createStep(int position) {
-            switch (position) {
-                case 0:
-                    return StepFragmentSample.newInstance(R.layout.fragment_step);
-                case 1:
-                    return StepFragmentSample.newInstance(R.layout.fragment_step2);
-                case 2:
-                    return StepFragmentSample.newInstance(R.layout.fragment_step3);
-                default:
-                    throw new IllegalArgumentException("Unsupported position: " + position);
-            }
-        }
-
-        @Override
-        public int getCount() {
-            return 3;
-        }
-
-        @StringRes
-        @Override
-        public int getNextButtonText(int position) {
-            switch (position) {
-                case 0:
-                    return R.string.ms_next;
-                case 1:
-                    return R.string.go_to_summary;
-                default:
-                    throw new IllegalArgumentException("Unsupported position: " + position);
-            }
-        }
-
-    }
 }

--- a/sample/src/main/java/com/stepstone/stepper/sample/MainActivity.java
+++ b/sample/src/main/java/com/stepstone/stepper/sample/MainActivity.java
@@ -68,6 +68,11 @@ public class MainActivity extends AppCompatActivity {
         startActivity(new Intent(this, StyledTabsActivity.class));
     }
 
+    @OnClick(R.id.errorOnBackTabs)
+    public void onErrorOnBackTabs(View view) {
+        startActivity(new Intent(this, ShowErrorOnBackTabActivity.class));
+    }
+
     @OnClick(R.id.combination)
     public void onCombination(View view) {
         startActivity(new Intent(this, CombinationActivity.class));

--- a/sample/src/main/java/com/stepstone/stepper/sample/MainActivity.java
+++ b/sample/src/main/java/com/stepstone/stepper/sample/MainActivity.java
@@ -93,4 +93,9 @@ public class MainActivity extends AppCompatActivity {
         startActivity(new Intent(this, ReturnButtonActivity.class));
     }
 
+    @OnClick(R.id.noFragments)
+    public void onNoFrag(View view){
+        startActivity(new Intent(this, NoFragmentsActivity.class));
+    }
+
 }

--- a/sample/src/main/java/com/stepstone/stepper/sample/NoFragmentsActivity.java
+++ b/sample/src/main/java/com/stepstone/stepper/sample/NoFragmentsActivity.java
@@ -1,33 +1,15 @@
-/*
-Copyright 2016 StepStone Services
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
-
 package com.stepstone.stepper.sample;
 
 import android.os.Bundle;
-import android.support.annotation.LayoutRes;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.widget.Toast;
 
 import com.stepstone.stepper.StepperLayout;
 import com.stepstone.stepper.VerificationError;
-import com.stepstone.stepper.sample.adapter.SampleFragmentStepAdapter;
+import com.stepstone.stepper.sample.adapter.SampleStepAdapter;
 
-public abstract class AbstractStepperActivity extends AppCompatActivity implements StepperLayout.StepperListener,
-        OnNavigationBarListener {
+public class NoFragmentsActivity extends AppCompatActivity implements StepperLayout.StepperListener, OnNavigationBarListener {
 
     private static final String CURRENT_STEP_POSITION_KEY = "position";
 
@@ -36,23 +18,12 @@ public abstract class AbstractStepperActivity extends AppCompatActivity implemen
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setTitle("Stepper sample");
-
-        setContentView(getLayoutResId());
+        setContentView(R.layout.activity_no_frag);
         mStepperLayout = (StepperLayout) findViewById(R.id.stepperLayout);
         int startingStepPosition = savedInstanceState != null ? savedInstanceState.getInt(CURRENT_STEP_POSITION_KEY) : 0;
-        mStepperLayout.setAdapter(new SampleFragmentStepAdapter(getSupportFragmentManager()), startingStepPosition);
-
+        SampleStepAdapter sampleStepAdapter = new SampleStepAdapter(this);
+        mStepperLayout.setAdapter(sampleStepAdapter, startingStepPosition);
         mStepperLayout.setListener(this);
-    }
-
-    @LayoutRes
-    protected abstract int getLayoutResId();
-
-    @Override
-    protected void onSaveInstanceState(Bundle outState) {
-        outState.putInt(CURRENT_STEP_POSITION_KEY, mStepperLayout.getCurrentStepPosition());
-        super.onSaveInstanceState(outState);
     }
 
     @Override
@@ -63,6 +34,12 @@ public abstract class AbstractStepperActivity extends AppCompatActivity implemen
         } else {
             finish();
         }
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        outState.putInt(CURRENT_STEP_POSITION_KEY, mStepperLayout.getCurrentStepPosition());
+        super.onSaveInstanceState(outState);
     }
 
     @Override

--- a/sample/src/main/java/com/stepstone/stepper/sample/ShowErrorOnBackTabActivity.java
+++ b/sample/src/main/java/com/stepstone/stepper/sample/ShowErrorOnBackTabActivity.java
@@ -1,0 +1,21 @@
+package com.stepstone.stepper.sample;
+
+import android.os.Bundle;
+
+/**
+ * Created by leonardo on 10/01/17.
+ */
+
+public class ShowErrorOnBackTabActivity extends AbstractStepperActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mStepperLayout.setShowErrorStateOnBack(true);
+    }
+
+    @Override
+    protected int getLayoutResId() {
+        return R.layout.activity_default_tabs;
+    }
+}

--- a/sample/src/main/java/com/stepstone/stepper/sample/adapter/DelayedTransitionFragmentStepAdapter.java
+++ b/sample/src/main/java/com/stepstone/stepper/sample/adapter/DelayedTransitionFragmentStepAdapter.java
@@ -1,0 +1,34 @@
+package com.stepstone.stepper.sample.adapter;
+
+import android.support.v4.app.FragmentManager;
+
+import com.stepstone.stepper.Step;
+import com.stepstone.stepper.adapter.AbstractFragmentStepAdapter;
+import com.stepstone.stepper.sample.R;
+import com.stepstone.stepper.sample.step.fragment.DelayedTransitionStepFragmentSample;
+
+public class DelayedTransitionFragmentStepAdapter extends AbstractFragmentStepAdapter {
+
+    public DelayedTransitionFragmentStepAdapter(FragmentManager fm) {
+        super(fm);
+    }
+
+    @Override
+    public Step createStep(int position) {
+        switch (position) {
+            case 0:
+                return DelayedTransitionStepFragmentSample.newInstance(R.layout.fragment_step);
+            case 1:
+                return DelayedTransitionStepFragmentSample.newInstance(R.layout.fragment_step2);
+            case 2:
+                return DelayedTransitionStepFragmentSample.newInstance(R.layout.fragment_step3);
+            default:
+                throw new IllegalArgumentException("Unsupported position: " + position);
+        }
+    }
+
+    @Override
+    public int getCount() {
+        return 3;
+    }
+}

--- a/sample/src/main/java/com/stepstone/stepper/sample/adapter/NextButtonsSampleFragmentStepAdapter.java
+++ b/sample/src/main/java/com/stepstone/stepper/sample/adapter/NextButtonsSampleFragmentStepAdapter.java
@@ -1,0 +1,48 @@
+package com.stepstone.stepper.sample.adapter;
+
+import android.support.annotation.StringRes;
+import android.support.v4.app.FragmentManager;
+
+import com.stepstone.stepper.Step;
+import com.stepstone.stepper.adapter.AbstractFragmentStepAdapter;
+import com.stepstone.stepper.sample.R;
+import com.stepstone.stepper.sample.step.fragment.StepFragmentSample;
+
+public class NextButtonsSampleFragmentStepAdapter extends AbstractFragmentStepAdapter {
+
+    public NextButtonsSampleFragmentStepAdapter(FragmentManager fm) {
+        super(fm);
+    }
+
+    @Override
+    public Step createStep(int position) {
+        switch (position) {
+            case 0:
+                return StepFragmentSample.newInstance(R.layout.fragment_step);
+            case 1:
+                return StepFragmentSample.newInstance(R.layout.fragment_step2);
+            case 2:
+                return StepFragmentSample.newInstance(R.layout.fragment_step3);
+            default:
+                throw new IllegalArgumentException("Unsupported position: " + position);
+        }
+    }
+
+    @Override
+    public int getCount() {
+        return 3;
+    }
+
+    @StringRes
+    @Override
+    public int getNextButtonText(int position) {
+        switch (position) {
+            case 0:
+                return R.string.ms_next;
+            case 1:
+                return R.string.go_to_summary;
+            default:
+                throw new IllegalArgumentException("Unsupported position: " + position);
+        }
+    }
+}

--- a/sample/src/main/java/com/stepstone/stepper/sample/adapter/SampleFragmentStepAdapter.java
+++ b/sample/src/main/java/com/stepstone/stepper/sample/adapter/SampleFragmentStepAdapter.java
@@ -1,0 +1,34 @@
+package com.stepstone.stepper.sample.adapter;
+
+import android.support.v4.app.FragmentManager;
+
+import com.stepstone.stepper.Step;
+import com.stepstone.stepper.adapter.AbstractFragmentStepAdapter;
+import com.stepstone.stepper.sample.R;
+import com.stepstone.stepper.sample.step.fragment.StepFragmentSample;
+
+public class SampleFragmentStepAdapter extends AbstractFragmentStepAdapter {
+
+    public SampleFragmentStepAdapter(FragmentManager fm) {
+        super(fm);
+    }
+
+    @Override
+    public Step createStep(int position) {
+        switch (position) {
+            case 0:
+                return StepFragmentSample.newInstance(R.layout.fragment_step);
+            case 1:
+                return StepFragmentSample.newInstance(R.layout.fragment_step2);
+            case 2:
+                return StepFragmentSample.newInstance(R.layout.fragment_step3);
+            default:
+                throw new IllegalArgumentException("Unsupported position: " + position);
+        }
+    }
+
+    @Override
+    public int getCount() {
+        return 3;
+    }
+}

--- a/sample/src/main/java/com/stepstone/stepper/sample/adapter/SampleStepAdapter.java
+++ b/sample/src/main/java/com/stepstone/stepper/sample/adapter/SampleStepAdapter.java
@@ -1,0 +1,66 @@
+package com.stepstone.stepper.sample.adapter;
+
+import android.content.Context;
+import android.support.v4.view.ViewPager;
+import android.util.SparseArray;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.stepstone.stepper.Step;
+import com.stepstone.stepper.adapter.AbstractStepAdapter;
+import com.stepstone.stepper.sample.step.view.StepViewSample;
+
+/**
+ * A naive implementation of {@link AbstractStepAdapter}.
+ * This does not keep the view data on rotation, etc.
+ * It also keeps a reference to the created views.
+ */
+public class SampleStepAdapter extends AbstractStepAdapter {
+
+    private final Context context;
+
+    private final SparseArray<Step> pages = new SparseArray<>();
+
+    public SampleStepAdapter(Context context) {
+        this.context = context;
+    }
+
+    @Override
+    public StepViewSample createStep(int position) {
+        return new StepViewSample(context);
+    }
+
+    @Override
+    public int getCount() {
+        return 3;
+    }
+
+    @Override
+    public Step findStep(ViewPager viewPager, int position) {
+        return pages.size() > 0 ? pages.get(position) : null;
+    }
+
+    @Override
+    public View instantiateItem(ViewGroup container, int position) {
+        Step step = pages.get(position);
+        if (step == null) {
+            step = createStep(position);
+            pages.put(position, step);
+        }
+
+        View stepView = (View) step;
+        container.addView(stepView);
+
+        return stepView;
+    }
+
+    @Override
+    public void destroyItem(ViewGroup container, int position, Object object) {
+        container.removeView((View) object);
+    }
+
+    @Override
+    public boolean isViewFromObject(View view, Object object) {
+        return view == object;
+    }
+}

--- a/sample/src/main/java/com/stepstone/stepper/sample/step/fragment/DelayedTransitionStepFragmentSample.java
+++ b/sample/src/main/java/com/stepstone/stepper/sample/step/fragment/DelayedTransitionStepFragmentSample.java
@@ -14,56 +14,45 @@ See the License for the specific language governing permissions and
 limitations under the License.
  */
 
-package com.stepstone.stepper.sample.step;
+package com.stepstone.stepper.sample.step.fragment;
 
-import android.content.Context;
 import android.os.Bundle;
+import android.os.Handler;
 import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
+import android.support.annotation.UiThread;
 import android.support.v4.app.Fragment;
+import android.support.v7.app.AlertDialog;
 import android.text.Html;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.animation.AnimationUtils;
 import android.widget.Button;
+import android.widget.Toast;
 
-import com.stepstone.stepper.Step;
+import com.stepstone.stepper.BlockingStep;
+import com.stepstone.stepper.StepperLayout;
 import com.stepstone.stepper.VerificationError;
-import com.stepstone.stepper.sample.OnNavigationBarListener;
 import com.stepstone.stepper.sample.R;
 
-public class StepFragmentSample extends Fragment implements Step {
+public class DelayedTransitionStepFragmentSample extends Fragment implements BlockingStep {
 
     private static final String CLICKS_KEY = "clicks";
-
-    private static final int TAP_THRESHOLD = 2;
 
     private static final String LAYOUT_RESOURCE_ID_ARG_KEY = "messageResourceId";
 
     private int i = 0;
 
     private Button button;
+    private AlertDialog dialog;
 
-    @Nullable
-    private OnNavigationBarListener onNavigationBarListener;
-
-    public static StepFragmentSample newInstance(@LayoutRes int layoutResId) {
+    public static DelayedTransitionStepFragmentSample newInstance(@LayoutRes int layoutResId) {
         Bundle args = new Bundle();
         args.putInt(LAYOUT_RESOURCE_ID_ARG_KEY, layoutResId);
-        StepFragmentSample fragment = new StepFragmentSample();
+        DelayedTransitionStepFragmentSample fragment = new DelayedTransitionStepFragmentSample();
         fragment.setArguments(args);
         return fragment;
-    }
-
-    @Override
-    public void onAttach(Context context) {
-        super.onAttach(context);
-        if (context instanceof OnNavigationBarListener) {
-            onNavigationBarListener = (OnNavigationBarListener) context;
-        }
     }
 
     @Override
@@ -73,19 +62,24 @@ public class StepFragmentSample extends Fragment implements Step {
             i = savedInstanceState.getInt(CLICKS_KEY);
         }
 
-        updateNavigationBar();
-
         button = (Button) v.findViewById(R.id.button);
         button.setText(Html.fromHtml("Taps: <b>" + i + "</b>"));
         button.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 button.setText(Html.fromHtml("Taps: <b>" + (++i) + "</b>"));
-                updateNavigationBar();
             }
         });
 
         return v;
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        if (dialog != null) {
+            dialog.dismiss();
+        }
     }
 
     @Override
@@ -96,27 +90,38 @@ public class StepFragmentSample extends Fragment implements Step {
 
     @Override
     public VerificationError verifyStep() {
-        return isAboveThreshold() ? null : new VerificationError("Click " + (TAP_THRESHOLD - i) + " more times!");
-    }
-
-    private boolean isAboveThreshold() {
-        return i >= TAP_THRESHOLD;
+        return null;
     }
 
     @Override
     public void onSelected() {
-        updateNavigationBar();
     }
 
     @Override
     public void onError(@NonNull VerificationError error) {
-        button.startAnimation(AnimationUtils.loadAnimation(getActivity(), R.anim.shake_error));
     }
 
-    private void updateNavigationBar() {
-        if (onNavigationBarListener != null) {
-            onNavigationBarListener.onChangeEndButtonsEnabled(isAboveThreshold());
-        }
+    @Override
+    @UiThread
+    public void onNextClicked(final StepperLayout.OnNextClickedCallback callback) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setView(R.layout.dialog_loader);
+        builder.setCancelable(false);
+        dialog = builder.show();
+        new Handler().postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                dialog.dismiss();
+                callback.goToNextStep();
+            }
+        }, 2000L);
+    }
+
+    @Override
+    @UiThread
+    public void onBackClicked(StepperLayout.OnBackClickedCallback callback) {
+        Toast.makeText(this.getContext(), "Your custom back action. Here you should cancel currently running operations", Toast.LENGTH_SHORT).show();
+        callback.goToPrevStep();
     }
 
     @Override

--- a/sample/src/main/java/com/stepstone/stepper/sample/step/view/StepViewSample.java
+++ b/sample/src/main/java/com/stepstone/stepper/sample/step/view/StepViewSample.java
@@ -1,0 +1,100 @@
+package com.stepstone.stepper.sample.step.view;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.text.Html;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.animation.AnimationUtils;
+import android.widget.Button;
+import android.widget.FrameLayout;
+
+import com.stepstone.stepper.Step;
+import com.stepstone.stepper.VerificationError;
+import com.stepstone.stepper.sample.OnNavigationBarListener;
+import com.stepstone.stepper.sample.R;
+
+/**
+ * Created by leonardo on 18/12/16.
+ */
+
+public class StepViewSample extends FrameLayout implements Step {
+
+    private static final int TAP_THRESHOLD = 2;
+
+    private int i = 0;
+
+    @Nullable
+    private OnNavigationBarListener onNavigationBarListener;
+
+    private Button button;
+
+    public StepViewSample(Context context) {
+        super(context);
+        init(context);
+    }
+
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        Context c = getContext();
+        if (c instanceof OnNavigationBarListener) {
+            this.onNavigationBarListener = (OnNavigationBarListener) c;
+        }
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        this.onNavigationBarListener = null;
+    }
+
+    private void init(Context context) {
+        View v = LayoutInflater.from(context).inflate(R.layout.fragment_step, this, true);
+        button = (Button) v.findViewById(R.id.button);
+
+        updateNavigationBar();
+
+        button = (Button) v.findViewById(R.id.button);
+        button.setText(Html.fromHtml("Taps: <b>" + i + "</b>"));
+        button.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                button.setText(Html.fromHtml("Taps: <b>" + (++i) + "</b>"));
+                updateNavigationBar();
+            }
+        });
+    }
+
+    private boolean isAboveThreshold() {
+        return i >= TAP_THRESHOLD;
+    }
+
+    @Override
+    public int getName() {
+        return R.string.app_name;
+    }
+
+    @Override
+    public VerificationError verifyStep() {
+        return isAboveThreshold() ? null : new VerificationError("Click " + (TAP_THRESHOLD - i) + " more times!");
+    }
+
+    private void updateNavigationBar() {
+        if (onNavigationBarListener != null) {
+            onNavigationBarListener.onChangeEndButtonsEnabled(isAboveThreshold());
+        }
+    }
+
+    @Override
+    public void onSelected() {
+        updateNavigationBar();
+    }
+
+    @Override
+    public void onError(@NonNull VerificationError error) {
+        button.startAnimation(AnimationUtils.loadAnimation(getContext(), R.anim.shake_error));
+    }
+
+}

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -59,6 +59,12 @@
             android:text="@string/styled_tabs" />
 
         <Button
+            android:id="@+id/errorOnBackTabs"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/error_back_tabs" />
+
+        <Button
             android:id="@+id/combination"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -88,5 +88,11 @@
             android:layout_height="wrap_content"
             android:text="@string/show_back_button" />
 
+        <Button
+            android:id="@+id/noFragments"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/no_fragments" />
+
     </LinearLayout>
 </ScrollView>

--- a/sample/src/main/res/layout/activity_no_frag.xml
+++ b/sample/src/main/res/layout/activity_no_frag.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.stepstone.stepper.StepperLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/stepperLayout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    app:ms_stepperType="dots"/>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="styled_progress_bar">Styled progress bar</string>
     <string name="default_tabs">Default tabs</string>
     <string name="styled_tabs">Styled tabs</string>
+    <string name="error_back_tabs">Keep error back tabs</string>
     <string name="combination">Dots in portrait, tabs in landscape</string>
     <string name="custom_page_transformer">Custom PageTransformer</string>
     <string name="delayed_transition">Delayed transition</string>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="delayed_transition">Delayed transition</string>
     <string name="different_next_buttons">Different next buttons</string>
     <string name="show_back_button">Show Back button on first step</string>
+    <string name="no_fragments">No Fragment Stepper</string>
 
     <string name="tab_title">Tab title</string>
     <string name="lorem_ipsum">Lorem ipsum dolor sit amet, sale viris intellegam usu eu, persius patrioque sea at. Ne salutandi repudiandae mei, cu mollis accusam mediocrem mea. Altera dolorem praesent at vis. Torquatos philosophia ad quo. Omnis adipiscing has ea, mel no hinc iudico percipit.</string>


### PR DESCRIPTION
I created this PR to address #32 enhancement.
My previous code from the #37 is also here, so, sorry for the long commit.
I'd suggest taking a look at https://github.com/stepstone-tech/android-material-stepper/commit/2c33eaf626368a40ecda9ec4947dec71262eb61f for code only of the #32 issue.
I managed the issue addressed by @zawadz88 :

> When we go to the previous step? If so, when we then go back to the failed step the regular state should be shown instead of the error state?

Adding a `showErrorStateOnBack` flag, so the user can choose whether or not to clean the error from the current step when moving back.

The main point I'd like to discuss is when we get an error on "complete" state, do all the necessary steps to get it right and press "complete" again. Currently the callback is correctly fired, but the "error" state is never cleared. Not sure if this should be treated, as most of the cases the user will move forward to another screen.

What are your thoughts on that ?

Thanks!