### PR TITLE
Error back

### DIFF
--- a/material-stepper/src/main/java/com/stepstone/stepper/StepperLayout.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/StepperLayout.java
@@ -47,6 +47,7 @@ import com.stepstone.stepper.internal.RightNavigationButton;
 import com.stepstone.stepper.internal.TabsContainer;
 import com.stepstone.stepper.type.AbstractStepperType;
 import com.stepstone.stepper.type.StepperTypeFactory;
+import com.stepstone.stepper.type.TabsStepperType;
 import com.stepstone.stepper.util.AnimationUtil;
 import com.stepstone.stepper.util.TintUtil;
 
@@ -204,6 +205,8 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
 
     private int mCurrentStepPosition;
 
+    private boolean mShowErrorStateOnBack;
+
     @NonNull
     private StepperListener mListener = StepperListener.NULL;
 
@@ -323,6 +326,14 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
 
     public void setCompleteButtonVerificationFailed(boolean verificationFailed) {
         mCompleteNavigationButton.setVerificationFailed(verificationFailed);
+    }
+
+    /**
+     * Set whether when going backwards should clear the error state from the Tab. Default is false
+     * @param mShowErrorStateOnBack
+     */
+    public void setShowErrorStateOnBack(boolean mShowErrorStateOnBack) {
+        this.mShowErrorStateOnBack = mShowErrorStateOnBack;
     }
 
     private void init(AttributeSet attrs, @AttrRes int defStyleAttr) {
@@ -455,6 +466,8 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
                 mTypeIdentifier = a.getInt(R.styleable.StepperLayout_ms_stepperType, DEFAULT_TAB_DIVIDER_WIDTH);
             }
 
+            mShowErrorStateOnBack = a.getBoolean(R.styleable.StepperLayout_ms_showErrorStateOnBack, false);
+
             a.recycle();
         }
     }
@@ -496,6 +509,11 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
         if (verifyCurrentStep(step)) {
             return;
         }
+
+        //if moving forward and got no errors, set hasError to false, so we can have the tab with the check mark.
+        if(mStepperType instanceof TabsStepperType)
+            mTabsContainer.setErrorStep(mCurrentStepPosition, false);
+
         OnNextClickedCallback onNextClickedCallback = new OnNextClickedCallback();
         if (step instanceof BlockingStep) {
             ((BlockingStep) step).onNextClicked(onNextClickedCallback);
@@ -517,6 +535,11 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
         Step step = findCurrentStep();
         if (step != null) {
             step.onError(verificationError);
+
+            //if moving forward and got errors, set hasError to true, showing the error drawable.
+            if(mStepperType instanceof TabsStepperType)
+                mTabsContainer.setErrorStep(mCurrentStepPosition, true);
+
         }
         mListener.onError(verificationError);
     }
@@ -544,6 +567,11 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
             } else {
                 mNextNavigationButton.setText(nextButtonTextForStep);
             }
+        }
+
+        //needs to be here in case user for any reason decide to change whether or not to show errors when going back.
+        if(mStepperType instanceof TabsStepperType) {
+            mTabsContainer.setShowErrorStateOnBack(mShowErrorStateOnBack);
         }
 
         mStepperType.onStepSelected(newStepPosition);

--- a/material-stepper/src/main/java/com/stepstone/stepper/StepperLayout.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/StepperLayout.java
@@ -175,6 +175,9 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
     @ColorInt
     private int mSelectedColor;
 
+    @ColorInt
+    private int mErrorColor;
+
     @DrawableRes
     private int mBottomNavigationBackground;
 
@@ -204,6 +207,8 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
     private AbstractStepperType mStepperType;
 
     private int mCurrentStepPosition;
+
+    private boolean mShowErrorState;
 
     private boolean mShowErrorStateOnBack;
 
@@ -297,6 +302,10 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
         return mUnselectedColor;
     }
 
+    public int getErrorColor() {
+        return mErrorColor;
+    }
+
     public int getTabStepDividerWidth() {
         return mTabStepDividerWidth;
     }
@@ -329,11 +338,19 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
     }
 
     /**
-     * Set whether when going backwards should clear the error state from the Tab. Default is false
+     * Set whether when going backwards should clear the error state from the Tab. Default is false.
      * @param mShowErrorStateOnBack
      */
     public void setShowErrorStateOnBack(boolean mShowErrorStateOnBack) {
         this.mShowErrorStateOnBack = mShowErrorStateOnBack;
+    }
+
+    /**
+     * Set whether the tab should display error or not. Default false.
+     * @param mShowErrorState
+     */
+    public void setShowErrorState(boolean mShowErrorState) {
+        this.mShowErrorState = mShowErrorState;
     }
 
     private void init(AttributeSet attrs, @AttrRes int defStyleAttr) {
@@ -425,12 +442,14 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
             if (a.hasValue(R.styleable.StepperLayout_ms_completeButtonColor)) {
                 mCompleteButtonColor = a.getColorStateList(R.styleable.StepperLayout_ms_completeButtonColor);
             }
-
             if (a.hasValue(R.styleable.StepperLayout_ms_activeStepColor)) {
                 mSelectedColor = a.getColor(R.styleable.StepperLayout_ms_activeStepColor, mSelectedColor);
             }
             if (a.hasValue(R.styleable.StepperLayout_ms_inactiveStepColor)) {
                 mUnselectedColor = a.getColor(R.styleable.StepperLayout_ms_inactiveStepColor, mUnselectedColor);
+            }
+            if (a.hasValue(R.styleable.StepperLayout_ms_errorColor)) {
+                mErrorColor = a.getColor(R.styleable.StepperLayout_ms_errorColor, mErrorColor);
             }
             if (a.hasValue(R.styleable.StepperLayout_ms_bottomNavigationBackground)) {
                 mBottomNavigationBackground = a.getResourceId(R.styleable.StepperLayout_ms_bottomNavigationBackground, mBottomNavigationBackground);
@@ -462,6 +481,8 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
 
             mShowBackButtonOnFirstStep = a.getBoolean(R.styleable.StepperLayout_ms_showBackButtonOnFirstStep, false);
 
+            mShowErrorState = a.getBoolean(R.styleable.StepperLayout_ms_showErrorState, false);
+
             if (a.hasValue(R.styleable.StepperLayout_ms_stepperType)) {
                 mTypeIdentifier = a.getInt(R.styleable.StepperLayout_ms_stepperType, DEFAULT_TAB_DIVIDER_WIDTH);
             }
@@ -477,6 +498,7 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
                 ContextCompat.getColorStateList(getContext(), R.color.ms_bottomNavigationButtonTextColor);
         mSelectedColor = ContextCompat.getColor(getContext(), R.color.ms_selectedColor);
         mUnselectedColor = ContextCompat.getColor(getContext(), R.color.ms_unselectedColor);
+        mErrorColor = ContextCompat.getColor(getContext(), R.color.ms_errorColor);
         mBottomNavigationBackground = R.color.ms_bottomNavigationBackgroundColor;
         mBackButtonText = getContext().getString(R.string.ms_back);
         mNextButtonText = getContext().getString(R.string.ms_next);
@@ -511,7 +533,7 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
         }
 
         //if moving forward and got no errors, set hasError to false, so we can have the tab with the check mark.
-        if(mStepperType instanceof TabsStepperType)
+        if(mShowErrorState && mStepperType instanceof TabsStepperType)
             mTabsContainer.setErrorStep(mCurrentStepPosition, false);
 
         OnNextClickedCallback onNextClickedCallback = new OnNextClickedCallback();
@@ -537,7 +559,7 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
             step.onError(verificationError);
 
             //if moving forward and got errors, set hasError to true, showing the error drawable.
-            if(mStepperType instanceof TabsStepperType)
+            if(mShowErrorState && mStepperType instanceof TabsStepperType)
                 mTabsContainer.setErrorStep(mCurrentStepPosition, true);
 
         }

--- a/material-stepper/src/main/java/com/stepstone/stepper/StepperLayout.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/StepperLayout.java
@@ -353,8 +353,9 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
      */
     public void setShowErrorState(boolean mShowErrorState) {
         this.mShowErrorState = mShowErrorState;
-      
-     /**
+    }
+
+    /**
      * Set the number of steps that should be retained to either side of the
      * current step in the view hierarchy in an idle state. Steps beyond this
      * limit will be recreated from the adapter when needed.
@@ -546,8 +547,8 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
         }
 
         //if moving forward and got no errors, set hasError to false, so we can have the tab with the check mark.
-        if(mShowErrorState && mStepperType instanceof TabsStepperType)
-            mTabsContainer.setErrorStep(mCurrentStepPosition, false);
+        if(mShowErrorState)
+            mStepperType.setErrorStep(mCurrentStepPosition, false);
 
         OnNextClickedCallback onNextClickedCallback = new OnNextClickedCallback();
         if (step instanceof BlockingStep) {
@@ -572,8 +573,8 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
             step.onError(verificationError);
 
             //if moving forward and got errors, set hasError to true, showing the error drawable.
-            if(mShowErrorState && mStepperType instanceof TabsStepperType)
-                mTabsContainer.setErrorStep(mCurrentStepPosition, true);
+            if(mShowErrorState)
+                mStepperType.setErrorStep(mCurrentStepPosition, true);
 
         }
         mListener.onError(verificationError);
@@ -584,6 +585,7 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
         if (verifyCurrentStep(step)) {
             return;
         }
+        mStepperType.setErrorStep(mCurrentStepPosition, false);
         mListener.onCompleted(completeButton);
     }
 
@@ -604,10 +606,7 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
         }
 
         //needs to be here in case user for any reason decide to change whether or not to show errors when going back.
-        if(mStepperType instanceof TabsStepperType) {
-            mTabsContainer.setShowErrorStateOnBack(mShowErrorStateOnBack);
-        }
-
+        mStepperType.showErrorStateOnBack(mShowErrorStateOnBack);
         mStepperType.onStepSelected(newStepPosition);
         mListener.onStepSelected(newStepPosition);
         Step step = mStepAdapter.findStep(mPager, newStepPosition);

--- a/material-stepper/src/main/java/com/stepstone/stepper/StepperLayout.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/StepperLayout.java
@@ -47,6 +47,7 @@ import com.stepstone.stepper.internal.RightNavigationButton;
 import com.stepstone.stepper.internal.TabsContainer;
 import com.stepstone.stepper.type.AbstractStepperType;
 import com.stepstone.stepper.type.StepperTypeFactory;
+import com.stepstone.stepper.util.AnimationUtil;
 import com.stepstone.stepper.util.TintUtil;
 
 /**
@@ -124,7 +125,7 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
             }
 
             mCurrentStepPosition++;
-            onUpdate(mCurrentStepPosition);
+            onUpdate(mCurrentStepPosition, true);
         }
 
     }
@@ -140,7 +141,7 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
                 return;
             }
             mCurrentStepPosition--;
-            onUpdate(mCurrentStepPosition);
+            onUpdate(mCurrentStepPosition, true);
         }
 
     }
@@ -259,7 +260,7 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
         new Handler().post(new Runnable() {
             @Override
             public void run() {
-                onUpdate(mCurrentStepPosition);
+                onUpdate(mCurrentStepPosition, false);
             }
         });
 
@@ -309,7 +310,7 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
 
     public void setCurrentStepPosition(int currentStepPosition) {
         this.mCurrentStepPosition = currentStepPosition;
-        onUpdate(currentStepPosition);
+        onUpdate(currentStepPosition, true);
     }
 
     public int getCurrentStepPosition() {
@@ -528,13 +529,13 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
         mListener.onCompleted(completeButton);
     }
 
-    private void onUpdate(int newStepPosition) {
+    private void onUpdate(int newStepPosition, boolean animate) {
         mPager.setCurrentItem(newStepPosition);
         boolean isLast = isLastPosition(newStepPosition);
         boolean isFirst = newStepPosition == 0;
-        mNextNavigationButton.setVisibility(isLast ? View.GONE : View.VISIBLE);
-        mCompleteNavigationButton.setVisibility(!isLast ? View.GONE : View.VISIBLE);
-        mBackNavigationButton.setVisibility(isFirst && !mShowBackButtonOnFirstStep ? View.GONE : View.VISIBLE);
+        AnimationUtil.fadeViewVisibility(mNextNavigationButton, isLast ? View.GONE : View.VISIBLE, animate);
+        AnimationUtil.fadeViewVisibility(mCompleteNavigationButton, !isLast ? View.GONE : View.VISIBLE, animate);
+        AnimationUtil.fadeViewVisibility(mBackNavigationButton, isFirst && !mShowBackButtonOnFirstStep ? View.GONE : View.VISIBLE, animate);
 
         if (!isLast) {
             int nextButtonTextForStep = mStepAdapter.getNextButtonText(newStepPosition);

--- a/material-stepper/src/main/java/com/stepstone/stepper/internal/StepTab.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/internal/StepTab.java
@@ -17,11 +17,14 @@ limitations under the License.
 package com.stepstone.stepper.internal;
 
 import android.content.Context;
+import android.content.res.ColorStateList;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.ColorInt;
 import android.support.annotation.StringRes;
 import android.support.v4.content.ContextCompat;
+import android.support.v4.graphics.drawable.DrawableCompat;
+import android.support.v7.widget.AppCompatImageView;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -48,6 +51,9 @@ public class StepTab extends RelativeLayout {
     @ColorInt
     private int mSelectedColor;
 
+    @ColorInt
+    private int mErrorColor;
+
     private final TextView mStepNumber;
 
     private final View mStepDivider;
@@ -56,7 +62,7 @@ public class StepTab extends RelativeLayout {
 
     private final ImageView mStepDoneIndicator;
 
-    private final ImageView mStepErrorIndicator;
+    private final AppCompatImageView mStepErrorIndicator;
 
     private int mDividerWidth = StepperLayout.DEFAULT_TAB_DIVIDER_WIDTH;
 
@@ -76,10 +82,11 @@ public class StepTab extends RelativeLayout {
 
         mSelectedColor = ContextCompat.getColor(context, R.color.ms_selectedColor);
         mUnselectedColor = ContextCompat.getColor(context, R.color.ms_unselectedColor);
+        mErrorColor = ContextCompat.getColor(context, R.color.ms_errorColor);
 
         mStepNumber = (TextView) findViewById(R.id.ms_stepNumber);
         mStepDoneIndicator = (ImageView) findViewById(R.id.ms_stepDoneIndicator);
-        mStepErrorIndicator = (ImageView) findViewById(R.id.ms_stepErrorIndicator);
+        mStepErrorIndicator = (AppCompatImageView) findViewById(R.id.ms_stepErrorIndicator);
         mStepDivider = findViewById(R.id.ms_stepDivider);
         mStepTitle = ((TextView) findViewById(R.id.ms_stepTitle));
     }
@@ -109,6 +116,7 @@ public class StepTab extends RelativeLayout {
 
         this.hasError = false;
 
+        mStepTitle.setTextColor(ContextCompat.getColor(getContext(), R.color.ms_black));
         mStepTitle.setTypeface(current ? Typeface.DEFAULT_BOLD : Typeface.DEFAULT);
         mStepTitle.setAlpha(done || current ? OPAQUE_ALPHA : INACTIVE_STEP_TITLE_ALPHA);
     }
@@ -122,6 +130,8 @@ public class StepTab extends RelativeLayout {
             mStepDoneIndicator.setVisibility(View.GONE);
             mStepNumber.setVisibility(View.GONE);
             mStepErrorIndicator.setVisibility(VISIBLE);
+            mStepErrorIndicator.setColorFilter(mErrorColor);
+            mStepTitle.setTextColor(mErrorColor);
         }
 
         this.hasError = hasError;
@@ -157,6 +167,10 @@ public class StepTab extends RelativeLayout {
 
     public void setSelectedColor(int selectedColor) {
         this.mSelectedColor = selectedColor;
+    }
+
+    public void setErrorColor(int errorColor) {
+        this.mErrorColor = errorColor;
     }
 
     private void colorViewBackground(View view, boolean selected) {

--- a/material-stepper/src/main/java/com/stepstone/stepper/internal/StepTab.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/internal/StepTab.java
@@ -124,13 +124,19 @@ public class StepTab extends RelativeLayout {
      * Update the error state of this tab. If it has error, show the error drawable.
      * @param hasError whether the tab has errors or not.
      */
-    public void updateErrorState(boolean hasError) {
+    public void updateErrorState(boolean done, boolean hasError) {
         if(hasError) {
             mStepDoneIndicator.setVisibility(View.GONE);
             mStepNumber.setVisibility(View.GONE);
             mStepErrorIndicator.setVisibility(VISIBLE);
             mStepErrorIndicator.setColorFilter(mErrorColor);
             mStepTitle.setTextColor(mErrorColor);
+        } else if(done) {
+            mStepDoneIndicator.setVisibility(View.VISIBLE);
+            mStepErrorIndicator.setVisibility(GONE);
+            colorViewBackground(mStepDoneIndicator, true);
+
+            mStepTitle.setTextColor(ContextCompat.getColor(getContext(), R.color.ms_black));
         }
 
         this.hasError = hasError;

--- a/material-stepper/src/main/java/com/stepstone/stepper/internal/StepTab.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/internal/StepTab.java
@@ -56,7 +56,11 @@ public class StepTab extends RelativeLayout {
 
     private final ImageView mStepDoneIndicator;
 
+    private final ImageView mStepErrorIndicator;
+
     private int mDividerWidth = StepperLayout.DEFAULT_TAB_DIVIDER_WIDTH;
+
+    private boolean hasError;
 
     public StepTab(Context context) {
         this(context, null);
@@ -75,6 +79,7 @@ public class StepTab extends RelativeLayout {
 
         mStepNumber = (TextView) findViewById(R.id.ms_stepNumber);
         mStepDoneIndicator = (ImageView) findViewById(R.id.ms_stepDoneIndicator);
+        mStepErrorIndicator = (ImageView) findViewById(R.id.ms_stepErrorIndicator);
         mStepDivider = findViewById(R.id.ms_stepDivider);
         mStepTitle = ((TextView) findViewById(R.id.ms_stepTitle));
     }
@@ -92,13 +97,34 @@ public class StepTab extends RelativeLayout {
      * @param done true if the step is done and the step's number should be replaced with a <i>done</i> icon, false otherwise
      * @param current true if the step is the current step, false otherwise
      */
-    public void updateState(final boolean done, final boolean current) {
+    public void updateState(final boolean done, final boolean showErrorOnBack, final boolean current) {
+        //if this tab has errors and the user decide not to clear when going backwards, simply ignore the update
+        if(this.hasError && showErrorOnBack)
+            return;
+
         mStepDoneIndicator.setVisibility(done ? View.VISIBLE : View.GONE);
         mStepNumber.setVisibility(!done ? View.VISIBLE : View.GONE);
+        mStepErrorIndicator.setVisibility(GONE);
         colorViewBackground(done ? mStepDoneIndicator : mStepNumber, done || current);
+
+        this.hasError = false;
 
         mStepTitle.setTypeface(current ? Typeface.DEFAULT_BOLD : Typeface.DEFAULT);
         mStepTitle.setAlpha(done || current ? OPAQUE_ALPHA : INACTIVE_STEP_TITLE_ALPHA);
+    }
+
+    /**
+     * Update the error state of this tab. If it has error, show the error drawable.
+     * @param hasError whether the tab has errors or not.
+     */
+    public void updateErrorState(boolean hasError) {
+        if(hasError) {
+            mStepDoneIndicator.setVisibility(View.GONE);
+            mStepNumber.setVisibility(View.GONE);
+            mStepErrorIndicator.setVisibility(VISIBLE);
+        }
+
+        this.hasError = hasError;
     }
 
     /**

--- a/material-stepper/src/main/java/com/stepstone/stepper/internal/TabsContainer.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/internal/TabsContainer.java
@@ -186,7 +186,7 @@ public class TabsContainer extends FrameLayout {
             return;
 
         StepTab childTab = (StepTab) mTabsInnerContainer.getChildAt(stepPosition);
-        childTab.updateErrorState(hasError);
+        childTab.updateErrorState(mStepTitles.size() - 1 == stepPosition ,hasError);
     }
   
     private View createStepTab(final int position, @Nullable CharSequence title) {

--- a/material-stepper/src/main/java/com/stepstone/stepper/internal/TabsContainer.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/internal/TabsContainer.java
@@ -79,6 +79,8 @@ public class TabsContainer extends FrameLayout {
 
     private List<Integer> mStepTitles;
 
+    private boolean mShowErrorStateOnBack;
+
     public TabsContainer(Context context) {
         this(context, null);
     }
@@ -152,11 +154,27 @@ public class TabsContainer extends FrameLayout {
             StepTab childTab = (StepTab) mTabsInnerContainer.getChildAt(i);
             boolean done = i < newStepPosition;
             final boolean current = i == newStepPosition;
-            childTab.updateState(done, current);
+            childTab.updateState(done, mShowErrorStateOnBack, current);
             if (current) {
                 mTabsScrollView.smoothScrollTo(childTab.getLeft() - mContainerLateralPadding, 0);
             }
         }
+    }
+
+    /**
+     * Set whether when going backwards should clear the error state from the Tab. Default is false
+     * @param mShowErrorStateOnBack
+     */
+    public void setShowErrorStateOnBack(boolean mShowErrorStateOnBack) {
+        this.mShowErrorStateOnBack = mShowErrorStateOnBack;
+    }
+
+    public void setErrorStep(int stepPosition, boolean hasError){
+        if(mStepTitles.size() < stepPosition)
+            return;
+
+        StepTab childTab = (StepTab) mTabsInnerContainer.getChildAt(stepPosition);
+        childTab.updateErrorState(hasError);
     }
 
     private View createStepTab(final int position, @StringRes int title) {

--- a/material-stepper/src/main/java/com/stepstone/stepper/internal/TabsContainer.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/internal/TabsContainer.java
@@ -67,6 +67,9 @@ public class TabsContainer extends FrameLayout {
     @ColorInt
     private int mSelectedColor;
 
+    @ColorInt
+    private int mErrorColor;
+
     private int mDividerWidth = StepperLayout.DEFAULT_TAB_DIVIDER_WIDTH;
 
     private final int mContainerLateralPadding;
@@ -95,6 +98,7 @@ public class TabsContainer extends FrameLayout {
 
         mSelectedColor = ContextCompat.getColor(context, R.color.ms_selectedColor);
         mUnselectedColor = ContextCompat.getColor(context, R.color.ms_unselectedColor);
+        mErrorColor = ContextCompat.getColor(context, R.color.ms_errorColor);
         if (attrs != null) {
             final TypedArray a = getContext().obtainStyledAttributes(
                     attrs, R.styleable.TabsContainer, defStyleAttr, 0);
@@ -104,6 +108,10 @@ public class TabsContainer extends FrameLayout {
             }
             if (a.hasValue(R.styleable.TabsContainer_ms_inactiveTabColor)) {
                 mUnselectedColor = a.getColor(R.styleable.TabsContainer_ms_inactiveTabColor, mUnselectedColor);
+            }
+
+            if (a.hasValue(R.styleable.StepperLayout_ms_errorColor)) {
+                mErrorColor = a.getColor(R.styleable.StepperLayout_ms_errorColor, mErrorColor);
             }
 
             a.recycle();
@@ -120,6 +128,10 @@ public class TabsContainer extends FrameLayout {
 
     public void setSelectedColor(@ColorInt int selectedColor) {
         this.mSelectedColor = selectedColor;
+    }
+
+    public void setErrorColor(@ColorInt int mErrorColor) {
+        this.mErrorColor = mErrorColor;
     }
 
     public void setDividerWidth(int dividerWidth) {
@@ -184,6 +196,7 @@ public class TabsContainer extends FrameLayout {
         view.setStepTitle(title);
         view.setSelectedColor(mSelectedColor);
         view.setUnselectedColor(mUnselectedColor);
+        view.setErrorColor(mErrorColor);
         view.setDividerWidth(mDividerWidth);
 
         view.setOnClickListener(new View.OnClickListener() {

--- a/material-stepper/src/main/java/com/stepstone/stepper/type/AbstractStepperType.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/type/AbstractStepperType.java
@@ -55,6 +55,19 @@ public abstract class AbstractStepperType {
     public abstract void onStepSelected(int newStepPosition);
 
     /**
+     * Called to set whether the stepPosition has an error or not, changing it's appearance.
+     * @param stepPosition the step to set the error
+     * @param hasError whether it has error or not
+     */
+    public void setErrorStep(int stepPosition, boolean hasError){ }
+
+    /**
+     * Called to set whether navigating backwards should keep the error state.
+     * @param mShowErrorStateOnBack
+     */
+    public void showErrorStateOnBack(boolean mShowErrorStateOnBack){ }
+
+    /**
      * Called when {@link StepperLayout}'s adapter gets changed
      * @param stepAdapter new stepper adapter
      */

--- a/material-stepper/src/main/java/com/stepstone/stepper/type/TabsStepperType.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/type/TabsStepperType.java
@@ -58,6 +58,22 @@ public class TabsStepperType extends AbstractStepperType {
      * {@inheritDoc}
      */
     @Override
+    public void setErrorStep(int stepPosition, boolean hasError) {
+        mTabsContainer.setErrorStep(stepPosition, hasError);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void showErrorStateOnBack(boolean mShowErrorStateOnBack) {
+        mTabsContainer.setShowErrorStateOnBack(mShowErrorStateOnBack);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void onNewAdapter(@NonNull StepAdapter stepAdapter) {
         List<CharSequence> titles = new ArrayList<>();
         final int stepCount = stepAdapter.getCount();

--- a/material-stepper/src/main/java/com/stepstone/stepper/type/TabsStepperType.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/type/TabsStepperType.java
@@ -41,6 +41,7 @@ public class TabsStepperType extends AbstractStepperType {
         mTabsContainer.setVisibility(View.VISIBLE);
         mTabsContainer.setSelectedColor(stepperLayout.getSelectedColor());
         mTabsContainer.setUnselectedColor(stepperLayout.getUnselectedColor());
+        mTabsContainer.setErrorColor(stepperLayout.getErrorColor());
         mTabsContainer.setDividerWidth(stepperLayout.getTabStepDividerWidth());
         mTabsContainer.setListener(stepperLayout);
     }

--- a/material-stepper/src/main/java/com/stepstone/stepper/util/AnimationUtil.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/util/AnimationUtil.java
@@ -1,0 +1,65 @@
+package com.stepstone.stepper.util;
+
+import android.animation.Animator;
+import android.support.annotation.IntDef;
+import android.support.annotation.NonNull;
+import android.view.View;
+import android.view.ViewPropertyAnimator;
+
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+/**
+ * Util class containing static methods to simplify animation.
+ */
+public final class AnimationUtil {
+
+    @Retention(SOURCE)
+    @IntDef({View.VISIBLE, View.INVISIBLE, View.GONE})
+    @interface Visibility {}
+
+    private static final int DEFAULT_DURATION = 300;
+
+    private AnimationUtil() {
+        throw new AssertionError("Please do not instantiate this class");
+    }
+
+    /**
+     * Animate the View's visibility using a fade animation.
+     * @param view The View to be animated
+     * @param visibility View visibility constant, can be either View.VISIBLE, View.INVISIBLE or View.GONE
+     */
+    public static void fadeViewVisibility(@NonNull final View view, @Visibility final int visibility, boolean animate) {
+        ViewPropertyAnimator animator = view.animate();
+        animator.cancel();
+        animator.alpha(visibility == View.VISIBLE ? 1 : 0)
+                .setDuration(animate ? DEFAULT_DURATION : 0)
+                .setListener(new Animator.AnimatorListener() {
+                    @Override
+                    public void onAnimationStart(@NonNull Animator animation) {
+                        if (visibility == View.VISIBLE) {
+                            view.setVisibility(visibility);
+                        }
+                    }
+
+                    @Override
+                    public void onAnimationEnd(@NonNull Animator animation) {
+                        if (visibility == View.INVISIBLE || visibility == View.GONE) {
+                            view.setVisibility(visibility);
+                        }
+                    }
+
+                    @Override
+                    public void onAnimationCancel(@NonNull Animator animation) {
+                        if (visibility == View.INVISIBLE || visibility == View.GONE) {
+                            view.setVisibility(visibility);
+                        }
+                    }
+
+                    @Override
+                    public void onAnimationRepeat(@NonNull Animator animation) {
+                    }
+                }).start();
+    }
+}

--- a/material-stepper/src/main/res/drawable/ic_warning.xml
+++ b/material-stepper/src/main/res/drawable/ic_warning.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M1,21h22L12,2 1,21zM13,18h-2v-2h2v2zM13,14h-2v-4h2v4z"/>
+</vector>

--- a/material-stepper/src/main/res/layout/ms_step_tab.xml
+++ b/material-stepper/src/main/res/layout/ms_step_tab.xml
@@ -27,6 +27,15 @@
             app:srcCompat="@drawable/ic_check"
             android:visibility="gone" />
 
+        <android.support.v7.widget.AppCompatImageView
+            android:id="@+id/ms_stepErrorIndicator"
+            android:layout_width="@dimen/ms_step_tab_counter_size"
+            android:layout_height="@dimen/ms_step_tab_counter_size"
+            android:scaleType="centerInside"
+            app:srcCompat="@drawable/ic_warning"
+            android:tint="@color/ms_errorColor"
+            android:visibility="gone" />
+
     </FrameLayout>
 
     <TextView

--- a/material-stepper/src/main/res/layout/ms_stepper_layout.xml
+++ b/material-stepper/src/main/res/layout/ms_stepper_layout.xml
@@ -82,6 +82,7 @@
             android:layout_alignParentEnd="true"
             android:layout_alignParentRight="true"
             android:layout_centerVertical="true"
+            android:alpha="0"
             android:visibility="gone"
             tools:text="@string/ms_complete"
             tools:textColor="@color/ms_bottomNavigationButtonTextColor"

--- a/material-stepper/src/main/res/values/attrs.xml
+++ b/material-stepper/src/main/res/values/attrs.xml
@@ -49,6 +49,9 @@ limitations under the License.
 
         <!-- Flag indicating if the Back (Previous step) button should be shown on the first step. False by default. -->
         <attr name="ms_showBackButtonOnFirstStep" format="boolean" />
+
+        <!-- Flag indicating wheter to keep showing the error state when user moves back. Only available with 'tabs' type. False by default. -->
+        <attr name="ms_showErrorStateOnBack" format="boolean" />
         
         <!-- REQUIRED: Type of the stepper-->
         <attr name="ms_stepperType">

--- a/material-stepper/src/main/res/values/attrs.xml
+++ b/material-stepper/src/main/res/values/attrs.xml
@@ -29,6 +29,8 @@ limitations under the License.
         <attr name="ms_inactiveStepColor" format="color|reference" />
         <!-- Background of the bottom navigation -->
         <attr name="ms_bottomNavigationBackground" format="reference" />
+        <!-- Error's color -->
+        <attr name="ms_errorColor" format="color|reference" />
 
         <!-- BACK button's background -->
         <attr name="ms_backButtonBackground" format="reference" />
@@ -50,7 +52,10 @@ limitations under the License.
         <!-- Flag indicating if the Back (Previous step) button should be shown on the first step. False by default. -->
         <attr name="ms_showBackButtonOnFirstStep" format="boolean" />
 
-        <!-- Flag indicating wheter to keep showing the error state when user moves back. Only available with 'tabs' type. False by default. -->
+        <!-- Flag indicating whether to show the error state. Only available with 'tabs' type. False by default. -->
+        <attr name="ms_showErrorState" format="boolean" />
+
+        <!-- Flag indicating whether to keep showing the error state when user moves back. Only available with 'tabs' type. False by default. -->
         <attr name="ms_showErrorStateOnBack" format="boolean" />
         
         <!-- REQUIRED: Type of the stepper-->

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -25,6 +25,8 @@
         <activity android:name=".DefaultTabsActivity" />
         <activity android:name=".StyledTabsActivity" />
         <activity android:name=".ShowErrorOnBackTabActivity"/>
+        <activity android:name=".ShowErrorTabActivity" />
+        <activity android:name=".ShowErrorCustomColorTabActivity" />
         <activity android:name=".CombinationActivity" />
         <activity android:name=".CustomPageTransformerActivity" />
         <activity android:name=".DelayedTransitionStepperActivity" />

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
         <activity android:name=".StyledProgressBarActivity" />
         <activity android:name=".DefaultTabsActivity" />
         <activity android:name=".StyledTabsActivity" />
+        <activity android:name=".ShowErrorOnBackTabActivity"/>
         <activity android:name=".CombinationActivity" />
         <activity android:name=".CustomPageTransformerActivity" />
         <activity android:name=".DelayedTransitionStepperActivity" />

--- a/sample/src/main/java/com/stepstone/stepper/sample/AbstractStepperActivity.java
+++ b/sample/src/main/java/com/stepstone/stepper/sample/AbstractStepperActivity.java
@@ -31,7 +31,7 @@ public abstract class AbstractStepperActivity extends AppCompatActivity implemen
 
     private static final String CURRENT_STEP_POSITION_KEY = "position";
 
-    StepperLayout mStepperLayout;
+    protected StepperLayout mStepperLayout;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/sample/src/main/java/com/stepstone/stepper/sample/MainActivity.java
+++ b/sample/src/main/java/com/stepstone/stepper/sample/MainActivity.java
@@ -68,6 +68,11 @@ public class MainActivity extends AppCompatActivity {
         startActivity(new Intent(this, StyledTabsActivity.class));
     }
 
+    @OnClick(R.id.errorOnBackTabs)
+    public void onErrorOnBackTabs(View view) {
+        startActivity(new Intent(this, ShowErrorOnBackTabActivity.class));
+    }
+
     @OnClick(R.id.combination)
     public void onCombination(View view) {
         startActivity(new Intent(this, CombinationActivity.class));

--- a/sample/src/main/java/com/stepstone/stepper/sample/MainActivity.java
+++ b/sample/src/main/java/com/stepstone/stepper/sample/MainActivity.java
@@ -68,6 +68,16 @@ public class MainActivity extends AppCompatActivity {
         startActivity(new Intent(this, StyledTabsActivity.class));
     }
 
+    @OnClick(R.id.errorTabs)
+    public void onErrorTabs(View view) {
+        startActivity(new Intent(this, ShowErrorTabActivity.class));
+    }
+
+    @OnClick(R.id.errorColorTabs)
+    public void onCustomColorErrorTabs(View view) {
+        startActivity(new Intent(this, ShowErrorCustomColorTabActivity.class));
+    }
+
     @OnClick(R.id.errorOnBackTabs)
     public void onErrorOnBackTabs(View view) {
         startActivity(new Intent(this, ShowErrorOnBackTabActivity.class));

--- a/sample/src/main/java/com/stepstone/stepper/sample/ShowErrorCustomColorTabActivity.java
+++ b/sample/src/main/java/com/stepstone/stepper/sample/ShowErrorCustomColorTabActivity.java
@@ -1,0 +1,12 @@
+package com.stepstone.stepper.sample;
+
+/**
+ * Created by leonardo on 1/16/17.
+ */
+
+public class ShowErrorCustomColorTabActivity extends AbstractStepperActivity {
+    @Override
+    protected int getLayoutResId() {
+        return R.layout.activity_error_custom_color_tabs;
+    }
+}

--- a/sample/src/main/java/com/stepstone/stepper/sample/ShowErrorOnBackTabActivity.java
+++ b/sample/src/main/java/com/stepstone/stepper/sample/ShowErrorOnBackTabActivity.java
@@ -1,0 +1,21 @@
+package com.stepstone.stepper.sample;
+
+import android.os.Bundle;
+
+/**
+ * Created by leonardo on 10/01/17.
+ */
+
+public class ShowErrorOnBackTabActivity extends AbstractStepperActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mStepperLayout.setShowErrorStateOnBack(true);
+    }
+
+    @Override
+    protected int getLayoutResId() {
+        return R.layout.activity_default_tabs;
+    }
+}

--- a/sample/src/main/java/com/stepstone/stepper/sample/ShowErrorOnBackTabActivity.java
+++ b/sample/src/main/java/com/stepstone/stepper/sample/ShowErrorOnBackTabActivity.java
@@ -11,6 +11,7 @@ public class ShowErrorOnBackTabActivity extends AbstractStepperActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        mStepperLayout.setShowErrorState(true);
         mStepperLayout.setShowErrorStateOnBack(true);
     }
 

--- a/sample/src/main/java/com/stepstone/stepper/sample/ShowErrorTabActivity.java
+++ b/sample/src/main/java/com/stepstone/stepper/sample/ShowErrorTabActivity.java
@@ -1,0 +1,13 @@
+package com.stepstone.stepper.sample;
+
+/**
+ * Created by leonardo on 1/16/17.
+ */
+
+public class ShowErrorTabActivity extends AbstractStepperActivity {
+
+    @Override
+    protected int getLayoutResId() {
+        return R.layout.activity_error_tabs;
+    }
+}

--- a/sample/src/main/res/layout/activity_error_custom_color_tabs.xml
+++ b/sample/src/main/res/layout/activity_error_custom_color_tabs.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.stepstone.stepper.StepperLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/stepperLayout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    app:ms_stepperType="tabs"
+    app:ms_showErrorState="true"
+    app:ms_errorColor="@color/colorButton"/>

--- a/sample/src/main/res/layout/activity_error_tabs.xml
+++ b/sample/src/main/res/layout/activity_error_tabs.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.stepstone.stepper.StepperLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/stepperLayout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    app:ms_stepperType="tabs"
+    app:ms_showErrorState="true" />

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -59,6 +59,18 @@
             android:text="@string/styled_tabs" />
 
         <Button
+            android:id="@+id/errorTabs"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/error_tabs" />
+
+        <Button
+            android:id="@+id/errorColorTabs"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/error_color_tabs" />
+
+        <Button
             android:id="@+id/errorOnBackTabs"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -59,6 +59,12 @@
             android:text="@string/styled_tabs" />
 
         <Button
+            android:id="@+id/errorOnBackTabs"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/error_back_tabs" />
+
+        <Button
             android:id="@+id/combination"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/sample/src/main/res/layout/activity_no_frag.xml
+++ b/sample/src/main/res/layout/activity_no_frag.xml
@@ -5,4 +5,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    app:ms_stepperType="dots"/>
+    app:ms_stepperType="tabs"
+    app:ms_showErrorState="true"
+    app:ms_showErrorStateOnBack="true"/>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -7,6 +7,8 @@
     <string name="styled_progress_bar">Styled progress bar</string>
     <string name="default_tabs">Default tabs</string>
     <string name="styled_tabs">Styled tabs</string>
+    <string name="error_tabs">Show errors on tabs</string>
+    <string name="error_color_tabs">Custom color error tabs</string>
     <string name="error_back_tabs">Keep error back tabs</string>
     <string name="combination">Dots in portrait, tabs in landscape</string>
     <string name="custom_page_transformer">Custom PageTransformer</string>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="styled_progress_bar">Styled progress bar</string>
     <string name="default_tabs">Default tabs</string>
     <string name="styled_tabs">Styled tabs</string>
+    <string name="error_back_tabs">Keep error back tabs</string>
     <string name="combination">Dots in portrait, tabs in landscape</string>
     <string name="custom_page_transformer">Custom PageTransformer</string>
     <string name="delayed_transition">Delayed transition</string>

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -16,6 +16,7 @@
         <item name="ms_inactiveStepColor">#006867</item>
         <item name="ms_backButtonColor">@color/ms_custom_button_text_color</item>
         <item name="ms_nextButtonColor">@color/ms_custom_button_text_color</item>
+        <item name="ms_errorColor">@color/ms_errorColor</item>
         <item name="ms_completeButtonColor">@color/ms_custom_button_text_color</item>
         <item name="ms_bottomNavigationBackground">?attr/colorAccent</item>
     </style>


### PR DESCRIPTION
I created this PR to address #32 enhancement.
My previous code from the #37 is also here, so, sorry for the long commit.
I'd suggest taking a look at https://github.com/stepstone-tech/android-material-stepper/commit/2c33eaf626368a40ecda9ec4947dec71262eb61f for code only of the #32 issue.
I managed the issue addressed by @zawadz88 :

> When we go to the previous step? If so, when we then go back to the failed step the regular state should be shown instead of the error state?

Adding a `showErrorStateOnBack` flag, so the user can choose whether or not to clean the error from the current step when moving back.

The main point I'd like to discuss is when we get an error on "complete" state, do all the necessary steps to get it right and press "complete" again. Currently the callback is correctly fired, but the "error" state is never cleared. Not sure if this should be treated, as most of the cases the user will move forward to another screen.

What are your thoughts on that ?

Thanks!