### PR TITLE
Implement blocking behavior for onComplete events

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,8 @@ In order to set that color:
 
 ### Make an IO operation before going to the next step (optional)
 If the user wants to e.g. save something in the database or make a network call on a separate Thread after clicking on the Next button
-he can perform these operations and then invoke the `goToNextStep()` method of the `StepperLayout.OnNextClickedCallback` in the current Step.
+he can perform these operations and then invoke the `goToNextStep()` method of the `StepperLayout.OnNextClickedCallback` in the current Step. If the user wants to perform
+the blocking operations on the final step, when clicking on the Complete button, he needs to invoke the `complete()` method of the  `StepperLayout.OnCompleteClickedCallback`.
 While operations are performed, and the user would like to go back you can cancel them and then invoke `onBackClicked()` method of the `StepperLayout.OnBackClickedCallback`.
 <p><img src ="./gifs/delayed-transition.gif" width="360" height="640"/></p>
 The fragment must implement `BlockingStep` instead of `Step`.
@@ -230,6 +231,17 @@ public class DelayedTransitionStepFragmentSample extends Fragment implements Blo
             @Override
             public void run() {
                 callback.goToNextStep();
+            }
+        }, 2000L);
+    }
+
+    @Override
+    @UiThread
+    public void onCompleteClicked(final StepperLayout.OnCompleteClickedCallback callback) {
+        new Handler().postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                callback.complete();
             }
         }, 2000L);
     }

--- a/material-stepper/src/main/java/com/stepstone/stepper/BlockingStep.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/BlockingStep.java
@@ -39,6 +39,17 @@ public interface BlockingStep extends Step {
     void onNextClicked(StepperLayout.OnNextClickedCallback callback);
 
     /**
+     * Notifies this step that the complete button/tab was clicked, the step was verified
+     * and the user can complete the flow. This is so that the current step might perform
+     * some last minute operations e.g. a network call before completing the flow.
+     * {@link StepperLayout.OnCompleteClickedCallback#complete()} must be called once these operations finish.
+     *
+     * @param callback callback to call once the user wishes to complete the flow
+     */
+    @UiThread
+    void onCompleteClicked(StepperLayout.OnCompleteClickedCallback callback);
+
+    /**
      * Notifies this step that the previous button/tab was clicked. This is so that the current step might perform
      * some last minute operations e.g. a network call before switching to previous step.
      * {@link StepperLayout.OnBackClickedCallback#goToPrevStep()} must be called once these operations finish.

--- a/material-stepper/src/main/java/com/stepstone/stepper/StepperLayout.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/StepperLayout.java
@@ -145,13 +145,8 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
 
         @UiThread
         public void complete() {
-            final int totalStepCount = mStepAdapter.getCount();
-
-            if (mCurrentStepPosition < totalStepCount - 1) {
-                return;
-            }
-
-            onComplete();
+            invalidateCurrentPosition();
+            mListener.onCompleted(mCompleteNavigationButton);
         }
 
     }
@@ -421,6 +416,7 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
     public void setShowErrorStateOnBackEnabled(boolean showErrorStateOnBackEnabled) {
         this.mShowErrorStateOnBackEnabled = showErrorStateOnBackEnabled;
     }
+
     /**
      * Set whether the errors should be displayed when they occur or not. Default is <code>false</code>.
      *
@@ -746,8 +742,13 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
             invalidateCurrentPosition();
             return;
         }
-        invalidateCurrentPosition();
-        mListener.onCompleted(mCompleteNavigationButton);
+
+        OnCompleteClickedCallback onCompleteClickedCallback = new OnCompleteClickedCallback();
+        if (step instanceof BlockingStep) {
+            ((BlockingStep) step).onCompleteClicked(onCompleteClickedCallback);
+        } else {
+            onCompleteClickedCallback.complete();
+        }
     }
 
     private void onUpdate(int newStepPosition, boolean userTriggeredChange) {

--- a/material-stepper/src/main/java/com/stepstone/stepper/StepperLayout.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/StepperLayout.java
@@ -141,6 +141,21 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
 
     }
 
+    public class OnCompleteClickedCallback extends AbstractOnButtonClickedCallback {
+
+        @UiThread
+        public void complete() {
+            final int totalStepCount = mStepAdapter.getCount();
+
+            if (mCurrentStepPosition < totalStepCount - 1) {
+                return;
+            }
+
+            onComplete();
+        }
+
+    }
+
     public class OnBackClickedCallback extends AbstractOnButtonClickedCallback {
 
         @UiThread

--- a/sample/src/main/java/com/stepstone/stepper/sample/step/fragment/DelayedTransitionStepFragmentSample.java
+++ b/sample/src/main/java/com/stepstone/stepper/sample/step/fragment/DelayedTransitionStepFragmentSample.java
@@ -87,6 +87,19 @@ public class DelayedTransitionStepFragmentSample extends ButterKnifeFragment imp
         }, 2000L);
     }
 
+    /**
+     * Notifies this step that the complete button/tab was clicked, the step was verified
+     * and the user can complete the flow. This is so that the current step might perform
+     * some last minute operations e.g. a network call before completing the flow.
+     * {@link StepperLayout.OnCompleteClickedCallback} must be called once these operations finish.
+     *
+     * @param callback callback to call once the user wishes to complete the flow
+     */
+    @Override
+    public void onCompleteClicked(StepperLayout.OnCompleteClickedCallback callback) {
+        // not needed here
+    }
+
     private boolean shouldOperationSucceed() {
         return operationSwitch.isChecked();
     }

--- a/sample/src/main/java/com/stepstone/stepper/sample/step/fragment/DelayedTransitionStepFragmentSample.java
+++ b/sample/src/main/java/com/stepstone/stepper/sample/step/fragment/DelayedTransitionStepFragmentSample.java
@@ -97,7 +97,7 @@ public class DelayedTransitionStepFragmentSample extends ButterKnifeFragment imp
      */
     @Override
     public void onCompleteClicked(StepperLayout.OnCompleteClickedCallback callback) {
-        // not needed here
+       callback.complete();
     }
 
     private boolean shouldOperationSucceed() {


### PR DESCRIPTION
Fix issue #83 

Add required callbacks and methods to implement the blocking step behavior  if the step is the last step from the flow ( meaning onNext() won't be called).

Summary : 

- add `OnCompleteClicked` callback
-  modify `LayoutStepper#onComplete()` to use the new callback
- modify `BlockingStep`  and add method for handling the complete event
- update sample app fragments that implement `BlockingStep`
