### PR TITLE
Disabled tab navigation issue fix + library update

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Moreover, you can find there other examples, e.g. how to persist state on rotati
 
 ### Download (from JCenter)
 ```groovy
-compile 'com.stepstone.stepper:material-stepper:3.2.0'
+compile 'com.stepstone.stepper:material-stepper:3.2.1'
 ```
 
 ### Create layout in XML

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ configure(allprojects) {
         androidTargetSdkVersion             = 25
         androidCompileSdkVersion            = 25
         androidBuildToolsVersion            = "25.0.2"
-        androidSupportLibraryVersion        = "25.2.0"
+        androidSupportLibraryVersion        = "25.3.1"
 
         junitVersion                        = "4.12"
         mockitoVersion                      = "1.10.19"

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@
 
 POM_GROUP_ID=com.stepstone.stepper
 POM_ARTIFACT_ID=material-stepper
-POM_VERSION=3.2.0
+POM_VERSION=3.2.1

--- a/material-stepper/src/main/java/com/stepstone/stepper/StepperLayout.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/StepperLayout.java
@@ -539,20 +539,24 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
     }
 
     /**
-     * Shows a progress indicator. This does not have to be a progress bar and it depends on chosen stepper feedback types.
+     * Shows a progress indicator if not already shown. This does not have to be a progress bar and it depends on chosen stepper feedback types.
      * @param progressMessage optional progress message if supported by the selected types
      */
     public void showProgress(@NonNull String progressMessage) {
-        mInProgress = true;
-        mStepperFeedbackType.showProgress(progressMessage);
+        if (!mInProgress) {
+            mStepperFeedbackType.showProgress(progressMessage);
+            mInProgress = true;
+        }
     }
 
     /**
-     * Hides the progress indicator.
+     * Hides the progress indicator if visible.
      */
     public void hideProgress() {
-        mInProgress = false;
-        mStepperFeedbackType.hideProgress();
+        if (mInProgress) {
+            mInProgress = false;
+            mStepperFeedbackType.hideProgress();
+        }
     }
 
     /**

--- a/material-stepper/src/main/java/com/stepstone/stepper/internal/feedback/TabsStepperFeedbackType.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/internal/feedback/TabsStepperFeedbackType.java
@@ -38,6 +38,8 @@ public class TabsStepperFeedbackType implements StepperFeedbackType {
 
     private final float mProgressMessageTranslationWhenHidden;
 
+    private boolean mTabNavigationEnabled;
+
     private TextView mProgressMessageTextView;
 
     private View mTabs;
@@ -54,6 +56,7 @@ public class TabsStepperFeedbackType implements StepperFeedbackType {
 
     @Override
     public void showProgress(@NonNull String progressMessage) {
+        mTabNavigationEnabled = mStepperLayout.isTabNavigationEnabled();
         setTabNavigationEnabled(false);
         mProgressMessageTextView.setText(progressMessage);
         mProgressMessageTextView.animate()
@@ -70,7 +73,7 @@ public class TabsStepperFeedbackType implements StepperFeedbackType {
 
     @Override
     public void hideProgress() {
-        setTabNavigationEnabled(true);
+        setTabNavigationEnabled(mTabNavigationEnabled);
 
         mProgressMessageTextView.animate()
                 .setStartDelay(0)


### PR DESCRIPTION
* Fixed an issue where tab navigation should be disabled when using 'tabs' stepper feedback & disabled tab navigation attribute (issue #105).
* Updated Android Support Library to 25.3.1
* Updated library version to 3.2.1