### PR TITLE
Added Right-To-Left (RTL) support to ViewPager

### DIFF
--- a/material-stepper/src/main/java/com/stepstone/stepper/StepperLayout.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/StepperLayout.java
@@ -243,6 +243,8 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
 
     private boolean mInProgress;
 
+    private boolean mIsRtlEnabled;
+
     @StyleRes
     private int mStepperLayoutTheme;
 
@@ -564,6 +566,14 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
     }
 
     /**
+     * Sets layout direction of mPager
+     * @param isRtlEnabled true if mPager should be swiped from right to left
+     */
+    public void setRtlEnabled(boolean isRtlEnabled) {
+        this.mIsRtlEnabled = isRtlEnabled;
+    }
+
+    /**
      * Sets the mask for the stepper feedback type.
      * @param feedbackTypeMask step feedback type mask, should contain one or more flags from {@link StepperFeedbackType}
      */
@@ -736,6 +746,8 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
 
             mTabNavigationEnabled = a.getBoolean(R.styleable.StepperLayout_ms_tabNavigationEnabled, true);
 
+            mIsRtlEnabled = a.getBoolean(com.stepstone.stepper.R.styleable.StepperLayout_ms_isRtlEnabled, false);
+
             mStepperLayoutTheme = a.getResourceId(R.styleable.StepperLayout_ms_stepperLayoutTheme, R.style.MSDefaultStepperLayoutTheme);
 
             a.recycle();
@@ -758,7 +770,12 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
     }
 
     private Step findCurrentStep() {
-        return mStepAdapter.findStep(mCurrentStepPosition);
+        int rtlPosition = (mStepAdapter.getCount() - 1) - mCurrentStepPosition;
+        if (mIsRtlEnabled) {
+            return mStepAdapter.findStep(rtlPosition);
+        } else {
+            return mStepAdapter.findStep(mCurrentStepPosition);
+        }
     }
 
     private void updateErrorFlagWhenGoingBack() {
@@ -822,7 +839,18 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
     }
 
     private void onUpdate(int newStepPosition, boolean userTriggeredChange) {
-        mPager.setCurrentItem(newStepPosition);
+        int rtlPosition = (mStepAdapter.getCount() - 1) - newStepPosition;
+        Step step;
+
+        if (mIsRtlEnabled) {
+            mPager.setCurrentItem(rtlPosition);
+            mListener.onStepSelected(rtlPosition);
+            step = mStepAdapter.findStep(rtlPosition);
+        } else {
+            mPager.setCurrentItem(newStepPosition);
+            mListener.onStepSelected(newStepPosition);
+            step = mStepAdapter.findStep(newStepPosition);
+        }
         final boolean isLast = isLastPosition(newStepPosition);
         final boolean isFirst = newStepPosition == 0;
         AnimationUtil.fadeViewVisibility(mNextNavigationButton, isLast ? View.GONE : View.VISIBLE, userTriggeredChange);
@@ -841,8 +869,6 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
         setCompoundDrawablesForNavigationButtons(viewModel.getBackButtonStartDrawableResId(), viewModel.getNextButtonEndDrawableResId());
 
         mStepperType.onStepSelected(newStepPosition, userTriggeredChange);
-        mListener.onStepSelected(newStepPosition);
-        Step step = mStepAdapter.findStep(newStepPosition);
         if (step != null) {
             step.onSelected();
         }

--- a/material-stepper/src/main/java/com/stepstone/stepper/adapter/AbstractFragmentStepAdapter.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/adapter/AbstractFragmentStepAdapter.java
@@ -41,20 +41,29 @@ public abstract class AbstractFragmentStepAdapter
     @NonNull
     protected final Context context;
 
+    private final boolean mRtlEnabled;
+
     public AbstractFragmentStepAdapter(@NonNull FragmentManager fm, @NonNull Context context) {
         super(fm);
         this.mFragmentManager = fm;
         this.context = context;
+        this.mRtlEnabled = context.getResources().getBoolean(R.bool.ms_rtlEnabled);
     }
 
     @Override
     public final Fragment getItem(@IntRange(from = 0) int position) {
+        if(mRtlEnabled) {
+            position = (this.getCount() - 1) - position;
+        }
         return (Fragment) createStep(position);
     }
 
     /** {@inheritDoc} */
     @SuppressWarnings("unchecked")
     public Step findStep(@IntRange(from = 0) int position) {
+        if(mRtlEnabled) {
+            position = (this.getCount() - 1) - position;
+        }
         String fragmentTag =  "android:switcher:" + R.id.ms_stepPager + ":" + this.getItemId(position);
         return (Step) mFragmentManager.findFragmentByTag(fragmentTag);
     }

--- a/material-stepper/src/main/res/values-ldrtl/booleans.xml
+++ b/material-stepper/src/main/res/values-ldrtl/booleans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <bool name="ms_rtlEnabled">true</bool>
+
+</resources>

--- a/material-stepper/src/main/res/values/attrs.xml
+++ b/material-stepper/src/main/res/values/attrs.xml
@@ -67,6 +67,9 @@ limitations under the License.
         <!-- Flag indicating whether step navigation is possible by clicking on the tabs directly. Only applicable for 'tabs' type. True by default. -->
         <attr name="ms_tabNavigationEnabled" format="boolean" />
 
+        <!-- Flag indicating whether mPager (ViewPager) should be swiped from right to left. False by default. -->
+        <attr name="ms_isRtlEnabled" format="boolean" />
+
         <!-- Type(s) of stepper feedback -->
         <attr name="ms_stepperFeedbackType">
             <flag name="none" value="1" />

--- a/material-stepper/src/main/res/values/attrs.xml
+++ b/material-stepper/src/main/res/values/attrs.xml
@@ -67,9 +67,6 @@ limitations under the License.
         <!-- Flag indicating whether step navigation is possible by clicking on the tabs directly. Only applicable for 'tabs' type. True by default. -->
         <attr name="ms_tabNavigationEnabled" format="boolean" />
 
-        <!-- Flag indicating whether mPager (ViewPager) should be swiped from right to left. False by default. -->
-        <attr name="ms_isRtlEnabled" format="boolean" />
-
         <!-- Type(s) of stepper feedback -->
         <attr name="ms_stepperFeedbackType">
             <flag name="none" value="1" />

--- a/material-stepper/src/main/res/values/booleans.xml
+++ b/material-stepper/src/main/res/values/booleans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <bool name="ms_rtlEnabled">false</bool>
+
+</resources>


### PR DESCRIPTION
This modification allows user to set ViewPager layout direction to Right-To-Left (RTL). Since top tabs and bottom navigation have RTL support by default, no change is required for those elements.

Important note: user must add fragments in reverse order at StepAdapter:createStep() as suggested here:
http://stackoverflow.com/questions/18781944/how-to-make-my-viewpager-swipe-from-right-to-left