### PR TITLE
Avoid race between updating stepper and ViewPager instantiating the steps

### DIFF
--- a/material-stepper/src/main/java/com/stepstone/stepper/StepperLayout.java
+++ b/material-stepper/src/main/java/com/stepstone/stepper/StepperLayout.java
@@ -22,7 +22,6 @@ import android.content.res.ColorStateList;
 import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
-import android.os.Handler;
 import android.support.annotation.AttrRes;
 import android.support.annotation.ColorInt;
 import android.support.annotation.DrawableRes;
@@ -40,6 +39,7 @@ import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewTreeObserver;
 import android.widget.Button;
 import android.widget.LinearLayout;
 
@@ -310,13 +310,13 @@ public class StepperLayout extends LinearLayout implements TabsContainer.TabItem
         mStepperType.onNewAdapter(stepAdapter);
 
         // this is so that the fragments in the adapter can be created BEFORE the onUpdate() method call
-        new Handler().post(new Runnable() {
+        mPager.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
             @Override
-            public void run() {
+            public void onGlobalLayout() {
+                mPager.getViewTreeObserver().removeGlobalOnLayoutListener(this);
                 onUpdate(mCurrentStepPosition, false);
             }
         });
-
     }
 
     /**


### PR DESCRIPTION
It was assuming the view pager has layed out all the steps at the time that it calls back to its listeners,
but that is not always true (Handler.post() is happening before ViewPager has inserted the step fragments into the
fragment manager).

This solution waits for the ViewPager to complete its layout before updating StepperLayout.