### PR TITLE
Filled progressbar

### DIFF
--- a/material-stepper/src/main/res/layout/ms_stepper_layout.xml
+++ b/material-stepper/src/main/res/layout/ms_stepper_layout.xml
@@ -46,6 +46,31 @@
         android:layout_width="match_parent"
         tools:style="@style/MSBottomNavigation">
 
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_centerInParent="true">
+
+            <com.stepstone.stepper.internal.widget.DottedProgressBar
+                android:id="@+id/ms_stepDottedProgressBar"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:layout_gravity="center"
+                android:visibility="gone" />
+
+            <com.stepstone.stepper.internal.widget.ColorableProgressBar
+                android:id="@+id/ms_stepProgressBar"
+                style="?attr/ms_colorableProgressBarStyle"
+                android:indeterminate="false"
+                android:visibility="gone"
+                tools:progress="33"
+                android:layout_gravity="center"
+                tools:style="@style/MSColorableProgressBar"
+                tools:visibility="visible" />
+
+        </FrameLayout>
+
         <Button
             android:id="@+id/ms_stepPrevButton"
             style="?attr/ms_backNavigationButtonStyle"
@@ -58,29 +83,6 @@
             tools:style="@style/MSNavBarButton.Back"
             tools:text="@string/ms_back"
             tools:textColor="@color/ms_bottomNavigationButtonTextColor" />
-
-        <FrameLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true">
-
-            <com.stepstone.stepper.internal.widget.DottedProgressBar
-                android:id="@+id/ms_stepDottedProgressBar"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:visibility="gone" />
-
-            <com.stepstone.stepper.internal.widget.ColorableProgressBar
-                android:id="@+id/ms_stepProgressBar"
-                style="?attr/ms_colorableProgressBarStyle"
-                android:indeterminate="false"
-                android:visibility="gone"
-                tools:progress="33"
-                tools:style="@style/MSColorableProgressBar"
-                tools:visibility="visible" />
-
-        </FrameLayout>
 
         <com.stepstone.stepper.internal.widget.RightNavigationButton
             android:id="@+id/ms_stepNextButton"

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -54,6 +54,7 @@
             android:name=".CustomStepperLayoutThemeActivity"
             android:theme="@style/AppThemeDark" />
         <activity android:name=".SetButtonColorProgrammaticallyActivity" />
+        <activity android:name=".FilledProgressBarActivity" />
     </application>
 
 </manifest>

--- a/sample/src/main/java/com/stepstone/stepper/sample/FilledProgressBarActivity.kt
+++ b/sample/src/main/java/com/stepstone/stepper/sample/FilledProgressBarActivity.kt
@@ -1,0 +1,24 @@
+/*
+Copyright 2016 StepStone Services
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.stepstone.stepper.sample
+
+class FilledProgressBarActivity : AbstractStepperActivity() {
+
+    override val layoutResId: Int
+        get() = R.layout.activity_filled_progress_bar
+
+}

--- a/sample/src/main/java/com/stepstone/stepper/sample/MainActivity.kt
+++ b/sample/src/main/java/com/stepstone/stepper/sample/MainActivity.kt
@@ -58,6 +58,7 @@ class MainActivity : AppCompatActivity() {
                 SampleItem(getString(R.string.themed_dots), getString(R.string.themed_dots_description), ThemedDotsActivity::class.java),
                 SampleItem(getString(R.string.default_progress_bar), getString(R.string.default_progress_bar_description), DefaultProgressBarActivity::class.java),
                 SampleItem(getString(R.string.styled_progress_bar), getString(R.string.styled_progress_bar_description), StyledProgressBarActivity::class.java),
+                SampleItem(getString(R.string.filled_progress_bar), getString(R.string.filled_progress_bar_description), FilledProgressBarActivity::class.java),
                 SampleItem(getString(R.string.default_tabs), getString(R.string.default_tabs_description), DefaultTabsActivity::class.java),
                 SampleItem(getString(R.string.styled_tabs), getString(R.string.styled_tabs_description), StyledTabsActivity::class.java),
                 SampleItem(getString(R.string.default_none), getString(R.string.default_none_description), DefaultNoneActivity::class.java),

--- a/sample/src/main/res/layout/activity_filled_progress_bar.xml
+++ b/sample/src/main/res/layout/activity_filled_progress_bar.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.stepstone.stepper.StepperLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/stepperLayout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:ms_stepperType="progress_bar"
+    app:ms_activeStepColor="#66bb67"
+    app:ms_inactiveStepColor="#006867"
+    app:ms_backButtonColor="#FFFFFF"
+    app:ms_nextButtonColor="#FFFFFF"
+    app:ms_completeButtonColor="#FFFFFF"
+    app:ms_bottomNavigationBackground="?attr/colorAccent"
+    app:ms_completeButtonBackground="@drawable/ms_button_background"
+    app:ms_stepperLayoutTheme="@style/FilledProgressStepperLayoutTheme"
+    tools:theme="@style/AppTheme" />

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="themed_dots">Themed dots</string>
     <string name="default_progress_bar">Default progress bar</string>
     <string name="styled_progress_bar">Styled progress bar</string>
+    <string name="filled_progress_bar">Filled progress bar</string>
     <string name="default_none">Default \'none\'</string>
     <string name="default_tabs">Default tabs</string>
     <string name="styled_tabs">Styled tabs</string>
@@ -32,6 +33,7 @@
     <string name="themed_dots_description">Dotted stepper styled through view attributes set in Activity theme</string>
     <string name="default_progress_bar_description">The default implementation of a stepper with a horizontal progress bar</string>
     <string name="styled_progress_bar_description">Horizontal progress bar stepper styled through view attributes in the layout file</string>
+    <string name="filled_progress_bar_description">Horizontal progress bar that fills the navigation bar</string>
     <string name="default_tabs_description">The default implementation of a tabbed stepper</string>
     <string name="styled_tabs_description">Tabbed stepper styled through view attributes in the layout file</string>
     <string name="default_none_description">The default implementation of a stepper without any particular current step indication</string>

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -55,6 +55,10 @@
         <item name="ms_completeNavigationButtonStyle">@style/CenteredCompleteButtonStyle</item>
     </style>
 
+    <style name="FilledProgressStepperLayoutTheme" parent="MSDefaultStepperLayoutTheme">
+        <item name="ms_colorableProgressBarStyle">@style/FilledProgressStepperLayoutStyle</item>
+    </style>
+
     <style name="CustomBottomNavigationStyle" parent="MSBottomNavigation">
         <item name="android:layout_height">40dp</item>
     </style>
@@ -91,6 +95,11 @@
     <style name="DarkStepTabSubtitleStyle" parent="MSStepTabSubtitle">
         <item name="android:textColor">@color/ms_white_54_opacity</item>
         <item name="fontPath">fonts/Oswald-Stencbab.ttf</item>
+    </style>
+
+    <style name="FilledProgressStepperLayoutStyle" parent="MSColorableProgressBar">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">match_parent</item>
     </style>
 
     <style name="MainCoordinatorLayoutStyle" />


### PR DESCRIPTION
Solves issue Filled ProgressBar #263

Slightly changed ms_stepper_layout to allow for a filled progress bar (fills width and height of the navigation bar) by setting a ms_stepperLayoutTheme similar to this:
    <style name="FilledProgressStepperLayoutTheme" parent="CustomStepperLayoutTheme">
        <item name="ms_colorableProgressBarStyle">@style/FilledProgressStepperLayoutStyle</item>
    </style>

    <style name="FilledProgressStepperLayoutStyle" parent="MSColorableProgressBar">
        <item name="android:layout_width">match_parent</item>
        <item name="android:layout_height">match_parent</item>
    </style>

The progress_bar stepper type can still be used as before by not applying a theme.